### PR TITLE
Add tests

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -1,0 +1,4 @@
+import * as AWS from "aws-sdk";
+
+// export default AWS;
+module.exports = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8333,9 +8333,9 @@
 			}
 		},
 		"react-dropzone": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-6.2.2.tgz",
-			"integrity": "sha512-rfzMk3d4d+oKHbF3/EWYESpc3nfVXU2dLxnJIgE8bqMnoPPkrIvAuR6gY1NpjdbPgQAg6HeqS/N0JG9tQhQqSA==",
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-6.2.4.tgz",
+			"integrity": "sha512-fkG/Nxalhai12FdNw9RZ6dIr1SctmRXWekkSoOKAhNDAECwDg4HWKuvvZVkEAedGNeAgmkQRVoqNfT8uje1zfg==",
 			"requires": {
 				"attr-accept": "^1.1.3",
 				"prop-types": "^15.6.2"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "roots": [
       "<rootDir>/src"
     ],
+    "testURL": "https://glossary-test.unexisting.url.com",
     "setupTestFrameworkScriptFile": "<rootDir>src/setupTests.js",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ajv-keywords": "^3.2.0",
     "aws-sdk": "^2.332.0",
     "clone": "^2.1.2",
-    "react-dropzone": "^6.2.2",
+    "react-dropzone": "^6.2.4",
     "react-json-editor-ajrm": "^2.5.6",
     "uuid": "^3.3.2"
   }

--- a/src/components/authoring/authoring-app.scss
+++ b/src/components/authoring/authoring-app.scss
@@ -1,9 +1,21 @@
-.authoring {
+.authoringApp {
+  h2 {
+    margin-top: 0;
+  }
+}
+
+.authoringColumn {
   display: inline-block;
   vertical-align: top;
-  margin-bottom: 50px;
-  width: 700px;
+  width: 600px;
+  margin-right: 70px;
 
+  & > * {
+    margin-bottom: 30px;
+  }
+}
+
+.authoring {
   input {
     display: inline-block;
   }
@@ -55,15 +67,13 @@
 }
 
 .jsonSection {
-  width: 600px;
-  display: inline-block;
-  vertical-align: top;
-  margin-right: 50px;
+
 }
 
 .preview {
   display: inline-block;
   vertical-align: top;
+  width: 600px;
 
   .handle {
     display: inline-block;
@@ -90,8 +100,10 @@
 }
 
 .laraPluginState {
-  width: 600px;
-  font-family: monospace;
+  .laraPluginStateJSON {
+    width: 600px;
+    font-family: monospace;
+  }
 }
 
 .help {
@@ -105,7 +117,7 @@
     font-size: 1.3em;
   }
   input {
-    width: 470px;
+    width: 440px;
   }
 }
 

--- a/src/components/authoring/authoring-app.test.tsx
+++ b/src/components/authoring/authoring-app.test.tsx
@@ -1,0 +1,236 @@
+import * as React from "react";
+import AuthoringApp, { DEFAULT_GLOSSARY, JSON_S3_DIR } from "./authoring-app";
+import JSONEditor from "./json-editor";
+import GlossarySidebar from "../glossary-sidebar";
+import DefinitionEditor from "./definition-editor";
+import { shallow } from "enzyme";
+import * as icons from "../icons.scss";
+import { s3Upload } from "../../utils/s3-helpers";
+
+import * as fetch from "jest-fetch-mock";
+(global as any).fetch = fetch;
+
+jest.mock("../../utils/s3-helpers");
+
+describe("AuthoringApp component", () => {
+  afterEach(() => {
+    // Cleaup.
+    history.replaceState({}, "Test", "/");
+    fetch.resetMocks();
+  });
+
+  it("renders basic UI", () => {
+    const wrapper = shallow(
+      <AuthoringApp/>
+    );
+    expect(wrapper.find("input[name='glossaryName']").length).toEqual(1);
+    expect(wrapper.find("input[name='s3AccessKey']").length).toEqual(1);
+    expect(wrapper.find("input[name='s3SecretKey']").length).toEqual(1);
+    expect(wrapper.find("[data-cy='save']").length).toEqual(1);
+    expect(wrapper.find("[data-cy='load']").length).toEqual(1);
+    expect(wrapper.find("[data-cy='askForUserChange']").length).toEqual(1);
+    expect(wrapper.find("[data-cy='addDef']").length).toEqual(1);
+    expect(wrapper.find(JSONEditor).length).toEqual(1);
+    expect(wrapper.find(GlossarySidebar).length).toEqual(1);
+  });
+
+  it("lets user add a new definition", () => {
+    const wrapper = shallow(
+      <AuthoringApp/>
+    );
+    const button = wrapper.find("[data-cy='addDef']");
+    button.simulate("click");
+    expect(wrapper.find(DefinitionEditor).length).toEqual(1);
+  });
+
+  it("updates JSON Editor and sidebar preview when a new definition is added or existing one removed", () => {
+    const wrapper = shallow(
+      <AuthoringApp/>
+    );
+    const component = wrapper.instance() as AuthoringApp;
+    const definition = { word: "test", definition: "definition" };
+
+    // Add a new definition.
+    component.addNewDef(definition);
+
+    // GlossarySidebar component.
+    expect(wrapper.find({ definitions: [ definition ]}).length).toEqual(1);
+    // JSONEditor component.
+    expect(wrapper.find({
+      initialValue: {
+        askForUserDefinition: true,
+        definitions: [ definition ]
+      }
+    }).length).toEqual(1);
+
+    // Now, remove it.
+    component.removeDef(definition.word);
+
+    // GlossarySidebar component.
+    expect(wrapper.find({ definitions: []}).length).toEqual(1);
+    // JSONEditor component.
+    expect(wrapper.find({
+      initialValue: {
+        askForUserDefinition: true,
+        definitions: []
+      }
+    }).length).toEqual(1);
+
+    // Toggle askForUserDefinition.
+    wrapper.find("[data-cy='askForUserChange']").simulate("change", { target: { checked: false }});
+
+    // JSONEditor component.
+    expect(wrapper.find({
+      initialValue: {
+        askForUserDefinition: false,
+        definitions: []
+      }
+    }).length).toEqual(1);
+  });
+
+  it("renders buttons that let you edit or remove an existing definition", () => {
+    const wrapper = shallow(
+      <AuthoringApp/>
+    );
+    const component = wrapper.instance() as AuthoringApp;
+    const definition = {word: "a very complex test word", definition: "definition"};
+
+    // Add a new definition.
+    component.addNewDef(definition);
+    expect(wrapper.text()).toEqual(expect.stringContaining(definition.word));
+
+    const remove = wrapper.find({ label: "Remove" });
+    expect(remove.length).toEqual(1);
+    remove.simulate("click");
+    expect(wrapper.text()).not.toEqual(expect.stringContaining(definition.word));
+
+    component.addNewDef(definition);
+    const edit = wrapper.find({ label: "Edit" });
+    expect(edit.length).toEqual(1);
+    edit.simulate("click");
+    expect(wrapper.find(DefinitionEditor).length).toEqual(1);
+  });
+
+  it("renders icons when definition has an image or video attached", () => {
+    const wrapper = shallow(
+      <AuthoringApp/>
+    );
+    const component = wrapper.instance() as AuthoringApp;
+    const definition = {
+      word: "a very complex test word",
+      definition: "definition",
+      image: "https://image.com",
+      video: "https://video.com",
+    };
+
+    // Add a new definition.
+    component.addNewDef(definition);
+    expect(wrapper.text()).toEqual(expect.stringContaining(definition.word));
+    expect(wrapper.find("." + icons.iconImage).length).toEqual(1);
+    expect(wrapper.find("." + icons.iconVideo).length).toEqual(1);
+  });
+
+  it("sets glossary name and S3 access key if they are provided in URL", () => {
+    history.replaceState({}, "Test", "/authoring.html?glossaryName=testName&s3AccessKey=testS3Key");
+    const wrapper = shallow(
+      <AuthoringApp/>
+    );
+    expect(wrapper.find("input[name='glossaryName']").props().value).toEqual("testName");
+    expect(wrapper.find("input[name='s3AccessKey']").props().value).toEqual("testS3Key");
+  });
+
+  it("should let user load JSON file if glossary name is provided", () => {
+    const glossary = {
+      definitions: [{word: "test1", definition: "test 1"}],
+      askForUserDefinition: false,
+    };
+
+    fetch.mockResponse(JSON.stringify(glossary));
+
+    const wrapper = shallow(
+      <AuthoringApp/>
+    );
+    const instance = wrapper.instance() as AuthoringApp;
+    instance.loadJSONFromS3 = jest.fn();
+
+    expect(wrapper.find("[data-cy='load']").props().disabled).toEqual(true);
+    wrapper.find("input[name='glossaryName']").simulate("change", {
+      target: { name: "glossaryName", value: "testName" }
+    });
+    const load = wrapper.find("[data-cy='load']");
+    expect(load.props().disabled).toEqual(false);
+    load.simulate("click");
+    expect(instance.loadJSONFromS3).toHaveBeenCalled();
+  });
+
+  it("should let user save JSON file if glossary name and S3 details are provided", () => {
+    const wrapper = shallow(
+      <AuthoringApp/>
+    );
+    const instance = wrapper.instance() as AuthoringApp;
+    instance.uploadJSONToS3 = jest.fn();
+
+    expect(wrapper.find("[data-cy='save']").props().disabled).toEqual(true);
+    wrapper.find("input[name='glossaryName']").simulate("change", {
+      target: { name: "glossaryName", value: "testName" }
+    });
+    wrapper.find("input[name='s3AccessKey']").simulate("change", {
+      target: { name: "s3AccessKey", value: "s3 access key" }
+    });
+    wrapper.find("input[name='s3SecretKey']").simulate("change", {
+      target: { name: "s3SecretKey", value: "s3 secret key" }
+    });
+    const save = wrapper.find("[data-cy='save']");
+    expect(save.props().disabled).toEqual(false);
+    save.simulate("click");
+    expect(instance.uploadJSONToS3).toHaveBeenCalled();
+  });
+
+  describe(".loadJSONFromS3() method", () => {
+    it("should download data and update JSON Editor and preview", async () => {
+      const glossary = {
+        definitions: [{word: "test1", definition: "test 1"}],
+        askForUserDefinition: false,
+      };
+
+      fetch.mockResponse(JSON.stringify(glossary));
+
+      const wrapper = shallow(
+        <AuthoringApp/>
+      );
+      await (wrapper.instance() as AuthoringApp).loadJSONFromS3();
+
+      expect(fetch).toHaveBeenCalled();
+      expect(wrapper.text()).toEqual(expect.stringContaining("Loading JSON: success!"));
+      expect(wrapper.find(JSONEditor).props().initialValue).toEqual(glossary);
+      expect(wrapper.find(GlossarySidebar).props().definitions).toEqual(glossary.definitions);
+    });
+  });
+
+  describe(".uploadJSONFromS3() method", () => {
+    it("should upload JSON to S3", async () => {
+      const wrapper = shallow(
+        <AuthoringApp/>
+      );
+      const glossaryName = "test";
+      const s3AccessKey = "s3AK";
+      const s3SecretKey = "s3SK";
+      wrapper.setState({
+        glossaryName,
+        s3AccessKey,
+        s3SecretKey
+      });
+      await (wrapper.instance() as AuthoringApp).uploadJSONToS3();
+      expect(s3Upload).toHaveBeenCalledWith({
+        dir: JSON_S3_DIR,
+        filename: glossaryName + ".json",
+        accessKey: s3AccessKey,
+        secretKey: s3SecretKey,
+        body: JSON.stringify(DEFAULT_GLOSSARY, null, 2),
+        contentType: "application/json",
+        cacheControl: "no-cache"
+      });
+      expect(wrapper.text()).toEqual(expect.stringContaining("Uploading JSON to S3: success!"));
+    });
+  });
+});

--- a/src/components/authoring/authoring-app.tsx
+++ b/src/components/authoring/authoring-app.tsx
@@ -13,7 +13,15 @@ import { validateGlossary } from "../../utils/validate-glossary";
 import * as css from "./authoring-app.scss";
 import * as icons from "../icons.scss";
 
-const JSON_S3_DIR = "json";
+export const JSON_S3_DIR = "json";
+export const DEFAULT_GLOSSARY = {
+  askForUserDefinition: true,
+  definitions: []
+};
+// Keys used to obtain dat from URL or local storage.
+const GLOSSARY_NAME = "glossaryName";
+const S3_ACCESS = "s3AccessKey";
+const S3_SECRET = "s3SecretKey";
 
 interface IState {
   glossary: IGlossary;
@@ -26,16 +34,6 @@ interface IState {
   s3ActionInProgress: boolean;
   s3Status: string;
 }
-
-// Keys used to obtain dat from URL or local storage.
-const GLOSSARY_NAME = "glossaryName";
-const S3_ACCESS = "s3AccessKey";
-const S3_SECRET = "s3SecretKey";
-
-const DEFAULT_GLOSSARY = {
-  askForUserDefinition: true,
-  definitions: []
-};
 
 const getStatusTxt = (msg: string) => `[${(new Date()).toLocaleTimeString()}] ${msg}`;
 
@@ -64,115 +62,124 @@ export default class PluginApp extends React.Component<{}, IState> {
       glossaryName, s3AccessKey, s3SecretKey, s3Status } = this.state;
     const { askForUserDefinition, definitions } = glossary;
     return (
-      <div>
-        <div>
-          <table className={css.s3Details}>
-            <tbody>
-            <tr className={css.name}>
-              <td>Glossary Name</td>
-              <td>
-                <input value={glossaryName} type="text" name="glossaryName" onChange={this.handleInputChange}/>
-              </td>
-            </tr>
-            <tr>
-              <td>S3 Access Key</td>
-              <td><input value={s3AccessKey} type="text" name="s3AccessKey" onChange={this.handleInputChange}/></td>
-            </tr>
-            <tr>
-              <td>S3 Secret Key</td>
-              <td><input value={s3SecretKey} type="text" name="s3SecretKey" onChange={this.handleInputChange}/></td>
-            </tr>
-            </tbody>
-          </table>
-          <p>
-            <Button label="Save" disabled={!this.s3FeaturesAvailable} onClick={this.uploadJSONToS3}/>
-            <Button label="Load" disabled={!this.s3FeaturesAvailable} onClick={this.loadJSONFromS3}/>
-          </p>
-          <div className={css.s3Status}>
-            {s3Status}
-          </div>
-        </div>
-        {
-          glossaryName &&
-          <div>
-            <h2>LARA Plugin State</h2>
-            <div className={css.help}>
-              Copy this snippet into LARA Plugin Authored state field. Remember to save your changes.
-            </div>
-            <div className={css.laraPluginState}>
-              {this.LARAPluginState}
+      <div className={css.authoringApp}>
+        <div className={css.authoringColumn}>
+          <div className={css.s3Details}>
+            <table>
+              <tbody>
+              <tr className={css.name}>
+                <td>Glossary Name</td>
+                <td>
+                  <input value={glossaryName} type="text" name="glossaryName" onChange={this.handleInputChange}/>
+                </td>
+              </tr>
+              <tr>
+                <td>S3 Access Key</td>
+                <td><input value={s3AccessKey} type="text" name="s3AccessKey" onChange={this.handleInputChange}/></td>
+              </tr>
+              <tr>
+                <td>S3 Secret Key</td>
+                <td><input value={s3SecretKey} type="text" name="s3SecretKey" onChange={this.handleInputChange}/></td>
+              </tr>
+              </tbody>
+            </table>
+            <p>
+              <Button label="Save" disabled={!this.s3FeaturesAvailable} data-cy="save" onClick={this.uploadJSONToS3}/>
+              <Button label="Load" disabled={!glossaryName} data-cy="load" onClick={this.loadJSONFromS3}/>
+            </p>
+            <div className={css.s3Status}>
+              {s3Status}
             </div>
           </div>
-        }
-        <div className={css.authoring}>
-          <h2>Glossary Authoring</h2>
-          <input type="checkbox" checked={askForUserDefinition} onChange={this.handleAskForUserDefChange}/>
-          <label>
-            Ask students for definition
-            <div className={css.help}>
-              When this option is turned on, students will have to provide their own definition
-              before they can see an authored one.
-            </div>
-          </label>
-          <h3>Definitions</h3>
-          <table className={css.definitionsTable}>
-            <tbody>
-              {
-                definitions.map(def => {
-                  if (definitionEditors[def.word]) {
-                    return <tr key={def.word} className={css.wordRow}><td colSpan={3}>
-                      <DefinitionEditor
-                        key={def.word}
-                        initialDefinition={def}
-                        s3AccessKey={s3AccessKey}
-                        s3SecretKey={s3SecretKey}
-                        onSave={this.editDef}
-                        onCancel={this.toggleDefinitionEditor.bind(this, def.word)}
-                      />
-                    </td></tr>;
-                  } else {
-                    return <tr key={def.word} className={css.wordRow}>
-                      <td className={css.definitionWord}>{def.word}</td>
-                      <td className={css.definitionTxt}>{def.definition}</td>
-                      <td className={css.definitionIcons}>
-                        {def.image && <span className={icons.iconImage}/>}
-                        {def.video && <span className={icons.iconVideo}/>}
-                      </td>
-                      <td className={css.definitionButtons}>
-                        <Button label="Edit" onClick={this.toggleDefinitionEditor.bind(this, def.word)}/>
-                        <Button label="Remove" onClick={this.removeDef.bind(this, def.word)}/>
-                      </td>
-                    </tr>;
-                  }
-                })
-              }
-            </tbody>
-          </table>
-          {!newDefEditor && <Button icon="iconPlus" label="Add a new definition" onClick={this.toggleNewDef}/>}
-          {
-            newDefEditor &&
-            <DefinitionEditor
-              onCancel={this.toggleNewDef}
-              onSave={this.addNewDef}
-              s3AccessKey={s3AccessKey}
-              s3SecretKey={s3SecretKey}
+          <div className={css.authoring}>
+            <input
+              type="checkbox"
+              checked={askForUserDefinition}
+              data-cy="askForUserChange"
+              onChange={this.handleAskForUserDefChange}
             />
-          }
-        </div>
-        <div className={css.jsonSection}>
-          <h2>Glossary JSON</h2>
-          <p><Button label="Copy JSON to clipboard" onClick={this.copyJSON}/></p>
-          <div className={css.help}>
-            Note that the editor below accepts and displays JS object syntax instead of the JSON notation.
-            Always use button above to copy correctly formatted JSON string.
+            <label>
+              Ask students for definition
+              <div className={css.help}>
+                When this option is turned on, students will have to provide their own definition
+                before they can see an authored one.
+              </div>
+            </label>
+            <h3>Definitions</h3>
+            <table className={css.definitionsTable}>
+              <tbody>
+                {
+                  definitions.map(def => {
+                    if (definitionEditors[def.word]) {
+                      return <tr key={def.word} className={css.wordRow}><td colSpan={3}>
+                        <DefinitionEditor
+                          key={def.word}
+                          initialDefinition={def}
+                          s3AccessKey={s3AccessKey}
+                          s3SecretKey={s3SecretKey}
+                          onSave={this.editDef}
+                          onCancel={this.toggleDefinitionEditor.bind(this, def.word)}
+                        />
+                      </td></tr>;
+                    } else {
+                      return <tr key={def.word} className={css.wordRow}>
+                        <td className={css.definitionWord}>{def.word}</td>
+                        <td className={css.definitionTxt}>{def.definition}</td>
+                        <td className={css.definitionIcons}>
+                          {def.image && <span className={icons.iconImage}/>}
+                          {def.video && <span className={icons.iconVideo}/>}
+                        </td>
+                        <td className={css.definitionButtons}>
+                          <Button label="Edit" onClick={this.toggleDefinitionEditor.bind(this, def.word)}/>
+                          <Button label="Remove" onClick={this.removeDef.bind(this, def.word)}/>
+                        </td>
+                      </tr>;
+                    }
+                  })
+                }
+              </tbody>
+            </table>
+            {
+              !newDefEditor &&
+              <Button icon="iconPlus" label="Add a new definition" data-cy="addDef" onClick={this.toggleNewDef}/>
+            }
+            {
+              newDefEditor &&
+              <DefinitionEditor
+                onCancel={this.toggleNewDef}
+                onSave={this.addNewDef}
+                s3AccessKey={s3AccessKey}
+                s3SecretKey={s3SecretKey}
+              />
+            }
           </div>
-          <JSONEditor
-            initialValue={jsonEditorContent}
-            onChange={this.handleJSONChange}
-            validate={validateGlossary}
-            width="600px"
-            height="400px"
-          />
+          {
+            glossaryName &&
+            <div className={css.laraPluginState}>
+              <h2>LARA Plugin State</h2>
+              <div className={css.help}>
+                Copy this snippet into LARA Plugin Authored state field. Remember to save your changes.
+              </div>
+              <div className={css.laraPluginStateJSON}>
+                {this.LARAPluginState}
+              </div>
+            </div>
+          }
+          <div className={css.jsonSection}>
+            <h2>Glossary JSON</h2>
+            <p><Button label="Copy JSON to clipboard" onClick={this.copyJSON}/></p>
+            <div className={css.help}>
+              Note that the editor below accepts and displays JS object syntax instead of the JSON notation.
+              Always use button above to copy correctly formatted JSON string.
+            </div>
+            <JSONEditor
+              initialValue={jsonEditorContent}
+              onChange={this.handleJSONChange}
+              validate={validateGlossary}
+              width="600px"
+              height="400px"
+            />
+          </div>
         </div>
         <div className={css.preview}>
           <h2>Preview</h2>
@@ -189,6 +196,95 @@ export default class PluginApp extends React.Component<{}, IState> {
         </div>
       </div>
     );
+  }
+
+  public addNewDef = (newDef: IWordDefinition) => {
+    const glossary: IGlossary = clone(this.state.glossary);
+    const definitionEditors = clone(this.state.definitionEditors);
+    // If there's already definition of this word, simply remove it.
+    const existingDefIdx = glossary.definitions.map(d => d.word).indexOf(newDef.word);
+    if (existingDefIdx !== -1) {
+      glossary.definitions.splice(existingDefIdx, 1);
+    }
+    glossary.definitions.push(newDef);
+    // Also, if user was editing this word, make sure that we disable editor.
+    definitionEditors[newDef.word] = false;
+    this.setState({ glossary, jsonEditorContent: glossary, definitionEditors, newDefEditor: false});
+  }
+
+  public removeDef = (word: string) => {
+    const glossary: IGlossary = clone(this.state.glossary);
+    const definitionEditors = clone(this.state.definitionEditors);
+    const existingDefIdx = glossary.definitions.map(d => d.word).indexOf(word);
+    if (existingDefIdx !== -1) {
+      glossary.definitions.splice(existingDefIdx, 1);
+    }
+    // Also, if user was editing this word, make sure that we disable editor (in case this word is added again later).
+    definitionEditors[word] = false;
+    this.setState({ glossary, jsonEditorContent: glossary, definitionEditors });
+  }
+
+  public loadJSONFromS3 = async () => {
+    this.setState({
+      s3ActionInProgress: true,
+      s3Status: getStatusTxt("Loading JSON...")
+    });
+    const response = await fetch(s3Url({ dir: JSON_S3_DIR, filename: this.glossaryFilename }));
+    if (response.status !== 200) {
+      this.setState({
+        s3ActionInProgress: false,
+        s3Status: getStatusTxt("Loading JSON failed" )
+      });
+      return;
+    }
+    try {
+      const textResponse = await response.text();
+      const json = JSON.parse(textResponse);
+      this.setState({
+        s3ActionInProgress: false,
+        s3Status: getStatusTxt("Loading JSON: success!"),
+        jsonEditorContent: json
+      });
+      // Update glossary definition only if it's valid. Otherwise, only JSON editor is updated and
+      // an author can fix possible errors.
+      if (validateGlossary(json).valid) {
+        this.setState({
+          glossary: json
+        });
+      }
+    } catch (error) {
+      this.setState({
+        s3ActionInProgress: false,
+        s3Status: getStatusTxt("Loading JSON failed: unexpected/malformed content")
+      });
+    }
+  }
+
+  public uploadJSONToS3 = () => {
+    this.setState({
+      s3ActionInProgress: true,
+      s3Status: getStatusTxt("Uploading JSON to S3...")
+    });
+    const { s3AccessKey, s3SecretKey } = this.state;
+    s3Upload({
+      dir: JSON_S3_DIR,
+      filename: this.glossaryFilename,
+      accessKey: s3AccessKey,
+      secretKey: s3SecretKey,
+      body: this.glossaryJSON,
+      contentType: "application/json",
+      cacheControl: "no-cache"
+    }).then(() => {
+      this.setState({
+        s3ActionInProgress: false,
+        s3Status: getStatusTxt("Uploading JSON to S3: success!")
+      });
+    }).catch(err => {
+      this.setState({
+        s3ActionInProgress: false,
+        s3Status: getStatusTxt(err)
+      });
+    });
   }
 
   private get glossaryFilename() {
@@ -248,69 +344,6 @@ export default class PluginApp extends React.Component<{}, IState> {
     this.setState({ glossary, jsonEditorContent: glossary });
   }
 
-  private uploadJSONToS3 = () => {
-    this.setState({
-      s3ActionInProgress: true,
-      s3Status: getStatusTxt("Uploading JSON to S3...")
-    });
-    const { s3AccessKey, s3SecretKey } = this.state;
-    s3Upload({
-      dir: JSON_S3_DIR,
-      filename: this.glossaryFilename,
-      accessKey: s3AccessKey,
-      secretKey: s3SecretKey,
-      body: this.glossaryJSON,
-      contentType: "application/json",
-      cacheControl: "no-cache"
-    }).then(() => {
-      this.setState({
-        s3ActionInProgress: false,
-        s3Status: getStatusTxt("Uploading JSON to S3: success!")
-      });
-    }).catch(err => {
-      this.setState({
-        s3ActionInProgress: false,
-        s3Status: getStatusTxt(err)
-      });
-    });
-  }
-
-  private loadJSONFromS3 = async () => {
-    this.setState({
-      s3ActionInProgress: true,
-      s3Status: getStatusTxt("Loading JSON...")
-    });
-    const response = await fetch(s3Url({ dir: JSON_S3_DIR, filename: this.glossaryFilename }));
-    if (response.status !== 200) {
-      this.setState({
-        s3ActionInProgress: false,
-        s3Status: getStatusTxt("Loading JSON failed" )
-      });
-      return;
-    }
-    try {
-      const textResponse = await response.text();
-      const json = JSON.parse(textResponse);
-      this.setState({
-        s3ActionInProgress: false,
-        s3Status: getStatusTxt("Loading JSON: success!"),
-        jsonEditorContent: json
-      });
-      // Update glossary definition only if it's valid. Otherwise, only JSON editor is updated and
-      // an author can fix possible errors.
-      if (validateGlossary(json).valid) {
-        this.setState({
-          glossary: json
-        });
-      }
-    } catch (error) {
-      this.setState({
-        s3ActionInProgress: false,
-        s3Status: getStatusTxt("Loading JSON failed: unexpected/malformed content")
-      });
-    }
-  }
-
   private toggleDefinitionEditor = (word: string) => {
     const definitionEditors = clone(this.state.definitionEditors);
     definitionEditors[word] = !definitionEditors[word];
@@ -329,32 +362,6 @@ export default class PluginApp extends React.Component<{}, IState> {
     glossary.definitions.splice(existingDefIdx, 1, newDef);
     // Disable editor.
     definitionEditors[newDef.word] = false;
-    this.setState({ glossary, jsonEditorContent: glossary, definitionEditors });
-  }
-
-  private addNewDef = (newDef: IWordDefinition) => {
-    const glossary: IGlossary = clone(this.state.glossary);
-    const definitionEditors = clone(this.state.definitionEditors);
-    // If there's already definition of this word, simply remove it.
-    const existingDefIdx = glossary.definitions.map(d => d.word).indexOf(newDef.word);
-    if (existingDefIdx !== -1) {
-      glossary.definitions.splice(existingDefIdx, 1);
-    }
-    glossary.definitions.push(newDef);
-    // Also, if user was editing this word, make sure that we disable editor.
-    definitionEditors[newDef.word] = false;
-    this.setState({ glossary, jsonEditorContent: glossary, definitionEditors, newDefEditor: false});
-  }
-
-  private removeDef = (word: string) => {
-    const glossary: IGlossary = clone(this.state.glossary);
-    const definitionEditors = clone(this.state.definitionEditors);
-    const existingDefIdx = glossary.definitions.map(d => d.word).indexOf(word);
-    if (existingDefIdx !== -1) {
-      glossary.definitions.splice(existingDefIdx, 1);
-    }
-    // Also, if user was editing this word, make sure that we disable editor (in case this word is added again later).
-    definitionEditors[word] = false;
     this.setState({ glossary, jsonEditorContent: glossary, definitionEditors });
   }
 }

--- a/src/components/authoring/button.test.tsx
+++ b/src/components/authoring/button.test.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import Button from "./button";
+import { shallow } from "enzyme";
+
+describe("Button component", () => {
+  it("renders basic UI", () => {
+    const wrapper = shallow(
+      <Button
+        label="test label"
+        onClick={jest.fn()}
+      />
+    );
+    expect(wrapper.text()).toEqual(expect.stringMatching("test label"));
+  });
+
+  it("calls onClick if it's not disabled", () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(
+      <Button
+        label="test label"
+        onClick={onClick}
+        disabled={false}
+      />
+    );
+    wrapper.simulate("click");
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("doesn't calls onClick if it's disabled", () => {
+    const onClick = jest.fn();
+    const wrapper = shallow(
+      <Button
+        label="test label"
+        onClick={onClick}
+        disabled={true}
+      />
+    );
+    wrapper.simulate("click");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/authoring/definition-editor.test.tsx
+++ b/src/components/authoring/definition-editor.test.tsx
@@ -1,0 +1,162 @@
+import * as React from "react";
+import DefinitionEditor, { MEDIA_S3_DIR } from "./definition-editor";
+import { shallow } from "enzyme";
+import { s3Upload } from "../../utils/s3-helpers";
+import {v1 as uuid} from "uuid";
+
+jest.mock("../../utils/s3-helpers");
+jest.mock("uuid", () => {
+  return {
+    v1: () => "mock-uuid"
+  };
+});
+// Can't test Dropzone features:
+// https://github.com/react-dropzone/react-dropzone/issues/554
+// None of the solution works both in the browser and Node.
+jest.mock("react-dropzone", () => {
+  return {default: "dropzone mock"};
+});
+
+const noop = () => undefined;
+
+describe("DefinitionEditor component", () => {
+  const s3AccessKey = "s3-access";
+  const s3SecretKey = "s3-secret";
+  const file = new File(["test"], "test-media.jpg", { type: "image/jpg" });
+
+  it("renders basic UI", () => {
+    const wrapper = shallow(
+      <DefinitionEditor
+        onSave={noop}
+        onCancel={noop}
+        s3AccessKey={s3AccessKey}
+        s3SecretKey={s3SecretKey}
+      />
+    );
+    expect(wrapper.find("input[name='word']").length).toEqual(1);
+    expect(wrapper.find("textarea[name='definition']").length).toEqual(1);
+    expect(wrapper.find("input[name='image']").length).toEqual(1);
+    expect(wrapper.find("input[name='imageCaption']").length).toEqual(1);
+    expect(wrapper.find("input[name='video']").length).toEqual(1);
+    expect(wrapper.find("input[name='videoCaption']").length).toEqual(1);
+    expect(wrapper.find("[data-cy='save']").length).toEqual(1);
+    expect(wrapper.find("[data-cy='cancel']").length).toEqual(1);
+  });
+
+  describe("saving", () => {
+    it("does not call onSave callback if there are any validation errors", () => {
+      const saveHandler = jest.fn();
+      const wrapper = shallow(
+        <DefinitionEditor
+          onSave={saveHandler}
+          onCancel={noop}
+          s3AccessKey={s3AccessKey}
+          s3SecretKey={s3SecretKey}
+        />
+      );
+      wrapper.setState({
+        definition: {
+          word: "",
+          definition: "",
+          image: "",
+          imageCaption: "",
+          video: "",
+          videoCaption: ""
+        }
+      });
+      expect(wrapper.state("error")).toEqual("");
+      wrapper.find("[data-cy='save']").simulate("click");
+      // "word" and "definition" values are missing.
+      expect(wrapper.state("error")).not.toEqual("");
+      expect(saveHandler).not.toHaveBeenCalled();
+    });
+
+    it("does call onSave callback if there are no validation errors", () => {
+      const saveHandler = jest.fn();
+      const wrapper = shallow(
+        <DefinitionEditor
+          onSave={saveHandler}
+          onCancel={noop}
+          s3AccessKey={s3AccessKey}
+          s3SecretKey={s3SecretKey}
+        />
+      );
+      wrapper.setState({
+        definition: {
+          word: "test",
+          definition: "definition",
+          image: "http://test.image.com/test.png",
+          imageCaption: "",
+          video: "",
+          videoCaption: ""
+        }
+      });
+      expect(wrapper.state("error")).toEqual("");
+      wrapper.find("[data-cy='save']").simulate("click");
+      expect(wrapper.state("error")).toEqual("");
+      // Note that properties equal to "" are removed!
+      expect(saveHandler).toHaveBeenCalledWith({
+        word: "test",
+        definition: "definition",
+        image: "http://test.image.com/test.png"
+      });
+    });
+
+    it("does call uploadMedia if there are some files to upload", () => {
+      const saveHandler = jest.fn();
+      const wrapper = shallow(
+        <DefinitionEditor
+          onSave={saveHandler}
+          onCancel={noop}
+          s3AccessKey={s3AccessKey}
+          s3SecretKey={s3SecretKey}
+        />
+      );
+      wrapper.setState({
+        definition: {
+          word: "test",
+          definition: "definition",
+          image: "",
+          imageCaption: "",
+          video: "",
+          videoCaption: ""
+        },
+        imageFile: file
+      });
+
+      const uploadMediaMock = jest.fn();
+      (wrapper.instance() as DefinitionEditor).uploadMedia = uploadMediaMock;
+
+      wrapper.find("[data-cy='save']").simulate("click");
+      expect(uploadMediaMock).toHaveBeenCalledWith(file);
+    });
+  });
+
+  describe(".uploadMedia() method", () => {
+    it("uploads a file to S3 bucket", async () => {
+      const wrapper = shallow(
+        <DefinitionEditor
+          onSave={noop}
+          onCancel={noop}
+          s3AccessKey={s3AccessKey}
+          s3SecretKey={s3SecretKey}
+        />
+      );
+
+      const url = await (wrapper.instance() as DefinitionEditor).uploadMedia(file);
+
+      expect(s3Upload).toHaveBeenCalledWith({
+        dir: MEDIA_S3_DIR,
+        filename: uuid() + "-" + file.name,
+        accessKey: s3AccessKey,
+        secretKey: s3SecretKey,
+        body: file,
+        contentType: file.type,
+        cacheControl: "max-age=31536000" // 1 year
+      });
+      expect(url).toEqual(
+        `https://test-resources.mock.concord.org/test-resources/${MEDIA_S3_DIR}/mock-uuid-${file.name}`
+      );
+    });
+  });
+});

--- a/src/components/authoring/json-editor.test.tsx
+++ b/src/components/authoring/json-editor.test.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import JSONEditor from "./json-editor";
+import JSONInput from "react-json-editor-ajrm";
+import { shallow } from "enzyme";
+
+describe("JSONEditor component", () => {
+  it("renders JSONInput UI", () => {
+    const wrapper = shallow(
+      <JSONEditor
+        width="500px"
+        height="500px"
+      />
+    );
+    expect(wrapper.find(JSONInput).length).toEqual(1);
+  });
+
+  it("passes initialValue to JSONInput", () => {
+    const test = {some: {test: {object: ""}}};
+    const wrapper = shallow(
+      <JSONEditor
+        width="500px"
+        height="500px"
+        initialValue={test}
+      />
+    );
+    expect(wrapper.find(JSONInput).prop("placeholder")).toEqual(test);
+  });
+
+  it("calls onChange when data is updated and passes validation", () => {
+    const test = {some: {test: {object: ""}}};
+    const onChange = jest.fn();
+    const validate = () => ({valid: true, error: ""});
+    const wrapper = shallow(
+      <JSONEditor
+        width="500px"
+        height="500px"
+        validate={validate}
+        onChange={onChange}
+        initialValue={test}
+      />
+    );
+    const newData = {jsObject: {newProp: "123"}};
+    wrapper.find(JSONInput).simulate("change", newData);
+    expect(onChange).toHaveBeenCalledWith(newData.jsObject);
+  });
+
+  it("doesn't call onChange when data is updated, but it doesn't pass validation", () => {
+    const test = {some: {test: {object: ""}}};
+    const onChange = jest.fn();
+    const errorTxt = "some error";
+    const validate = () => ({valid: false, error: errorTxt});
+    const wrapper = shallow(
+      <JSONEditor
+        width="500px"
+        height="500px"
+        validate={validate}
+        onChange={onChange}
+        initialValue={test}
+      />
+    );
+    const newData = {jsObject: {newProp: "123"}};
+    wrapper.find(JSONInput).simulate("change", newData);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(wrapper.text()).toEqual(expect.stringMatching(errorTxt));
+  });
+});

--- a/src/components/authoring/json-editor.tsx
+++ b/src/components/authoring/json-editor.tsx
@@ -51,7 +51,7 @@ export default class JSONEditor extends React.Component<IProps, IState> {
     );
   }
 
-  private handleJSONChange = (data: any) => {
+  public handleJSONChange = (data: any) => {
     if (!data.jsObject) {
       // There is some syntax error. Docs:
       // https://github.com/AndrewRedican/react-json-editor-ajrm#content-values

--- a/src/glossary-definition-schema.ts
+++ b/src/glossary-definition-schema.ts
@@ -1,6 +1,7 @@
 // Generated using https://www.jsonschema.net/
 // It can infer schema from the example. Then, it's easy to modify initial schema.
 
+/* tslint:disable */
 export default {
   "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -101,4 +102,4 @@ export default {
       }
     }
   }
-}
+};

--- a/src/utils/__mocks__/s3-helpers.ts
+++ b/src/utils/__mocks__/s3-helpers.ts
@@ -1,0 +1,13 @@
+export const S3_DIR_PREFIX = "test-resources";
+export const CLOUDFRONT_URL = "https://test-resources.mock.concord.org";
+
+export const s3Upload = jest.fn(({ dir, filename }: any) => {
+  const key = `${S3_DIR_PREFIX}/${dir}/${filename}`;
+  return new Promise(resolve => {
+    resolve(`${CLOUDFRONT_URL}/${key}`);
+  });
+});
+
+export const s3Url = jest.fn(({ filename, dir }: { filename: string; dir: string; }) => {
+  return `${CLOUDFRONT_URL}/${S3_DIR_PREFIX}/${dir}/${filename}`;
+});

--- a/src/utils/s3-helpers.test.tsx
+++ b/src/utils/s3-helpers.test.tsx
@@ -1,0 +1,46 @@
+import {s3Upload, s3Url, CLOUDFRONT_URL, S3_BUCKET, S3_DIR_PREFIX} from "./s3-helpers";
+import * as AWS from "aws-sdk";
+
+describe("S3 helpers", () => {
+  describe("s3Upload", () => {
+    beforeEach(() => {
+      AWS.S3.prototype.upload = jest.fn((params) => {
+        return {
+          promise: () => new Promise(resolve => {
+            resolve({ Key: `${params.Key}`});
+          })
+        };
+      });
+    });
+
+    it("should call AWS.S3.upload with correct arguments and return Cloudfront URL", async () => {
+      const params = {
+        dir: "test",
+        filename: "test.txt",
+        accessKey: "123",
+        secretKey: "abc",
+        body: "test",
+        cacheControl: "max-age=123",
+        contentType: "application/test"
+      };
+      const url = await s3Upload(params);
+      expect(AWS.S3.prototype.upload).toHaveBeenCalledTimes(1);
+      const expectedKey = `${S3_DIR_PREFIX}/${params.dir}/${params.filename}`;
+      expect(AWS.S3.prototype.upload).toHaveBeenCalledWith({
+        Bucket: S3_BUCKET,
+        Key: expectedKey,
+        Body: params.body,
+        ACL: "public-read",
+        ContentType: params.contentType,
+        CacheControl: params.cacheControl
+      });
+      expect(url).toEqual(`${CLOUDFRONT_URL}/${expectedKey}`);
+    });
+  });
+
+  describe("s3Url", () => {
+    describe("it should return Cloudfront URL for a given file and directory", () => {
+      expect(s3Url({filename: "test.abc", dir: "dir"})).toEqual(`${CLOUDFRONT_URL}/${S3_DIR_PREFIX}/dir/test.abc`);
+    });
+  });
+});

--- a/src/utils/s3-helpers.ts
+++ b/src/utils/s3-helpers.ts
@@ -1,11 +1,11 @@
 import * as AWS from "aws-sdk";
 
-const S3_BUCKET = "models-resources";
-const S3_DIR_PREFIX = "glossary-resources";
-const S3_REGION = "us-east-1";
-const CLOUDFRONT_URL = "https://models-resources.concord.org";
+export const S3_BUCKET = "models-resources";
+export const S3_DIR_PREFIX = "glossary-resources";
+export const S3_REGION = "us-east-1";
+export const CLOUDFRONT_URL = "https://models-resources.concord.org";
 
-interface IParams {
+export interface IParams {
   dir: string;
   filename: string;
   accessKey: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "allowJs": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
     "strictNullChecks": true,
     "jsx": "react",
     "lib": [


### PR DESCRIPTION
This PR mostly adds tests. Sometimes it required to reorganize base classes (mostly change methods form private to public). Also, there're some layout changes, demo:
http://glossary-plugin.concord.org/branch/160794190-authoring-s3-tests/authoring.html

Test coverage now (you can see authoring and utils at the bottom):
<img width="693" alt="screen shot 2018-10-17 at 19 49 05" src="https://user-images.githubusercontent.com/767857/47106093-064c2f80-d246-11e8-9423-90da11069288.png">

I had a lot of problems with Dropzone component which I could build either in webpack or node, but not in both. Finally, I've managed to mock it. I don't think it's worth trying to get it working, as it's an external component, well known, and interaction with it is pretty simple.