### PR TITLE
Update LARA Plugin API to V3, use NPM package for type checking, update tests

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -1,4 +1,0 @@
-import * as AWS from "aws-sdk";
-
-// export default AWS;
-module.exports = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,26 @@
 			}
 		},
 		"@concord-consortium/lara-plugin-api": {
-			"version": "3.0.0-pre.2",
+			"version": "3.0.0-pre.3",
+			"resolved": "https://registry.npmjs.org/@concord-consortium/lara-plugin-api/-/lara-plugin-api-3.0.0-pre.3.tgz",
+			"integrity": "sha512-5uK782UsHm6gU1PvAdpuMcHRuswCUYJlDNluivhZXzQD1pgy5kHIbfUMy7inby4Rqbwi28Fy76VshtAw1KBEXA==",
 			"requires": {
 				"@concord-consortium/text-decorator": "^1.0.2"
+			}
+		},
+		"@concord-consortium/text-decorator": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@concord-consortium/text-decorator/-/text-decorator-1.0.2.tgz",
+			"integrity": "sha512-60+KWiUlJ9YhxgHPfJsDuizBUXgJ3J5MDPIkAZrkl6Zd/yryTEaSfnA0ax7btUGOwKnyiKZCcMdVrNPxVAZBtA==",
+			"requires": {
+				"parse5": "^5.0.0"
+			},
+			"dependencies": {
+				"parse5": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+				}
 			}
 		},
 		"@types/cheerio": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,12 @@
 				}
 			}
 		},
+		"@concord-consortium/lara-plugin-api": {
+			"version": "3.0.0-pre.2",
+			"requires": {
+				"@concord-consortium/text-decorator": "^1.0.2"
+			}
+		},
 		"@types/cheerio": {
 			"version": "0.22.9",
 			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.9.tgz",
@@ -3449,7 +3455,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3470,12 +3477,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3490,17 +3499,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3617,7 +3629,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3629,6 +3642,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3643,6 +3657,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3650,12 +3665,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3674,6 +3691,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3754,7 +3772,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3766,6 +3785,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3851,7 +3871,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3887,6 +3908,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3906,6 +3928,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3949,12 +3972,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
 			}
 		},
 		"@concord-consortium/lara-plugin-api": {
-			"version": "3.0.0-pre.3",
-			"resolved": "https://registry.npmjs.org/@concord-consortium/lara-plugin-api/-/lara-plugin-api-3.0.0-pre.3.tgz",
-			"integrity": "sha512-5uK782UsHm6gU1PvAdpuMcHRuswCUYJlDNluivhZXzQD1pgy5kHIbfUMy7inby4Rqbwi28Fy76VshtAw1KBEXA==",
+			"version": "3.0.0-pre.7",
+			"resolved": "https://registry.npmjs.org/@concord-consortium/lara-plugin-api/-/lara-plugin-api-3.0.0-pre.7.tgz",
+			"integrity": "sha512-qPNhsoep3JFxzjVtfdieA0Go2CwcHjDyeojefYLkYFYQhqpqRgcJ/fuexWU1lIIUsCV1Thewsc9nQw+aIbnYCw==",
 			"requires": {
 				"@concord-consortium/text-decorator": "^1.0.2"
 			}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-dom": "^16.4.2"
   },
   "dependencies": {
-    "@concord-consortium/lara-plugin-api": "3.0.0-pre.2",
+    "@concord-consortium/lara-plugin-api": "3.0.0-pre.3",
     "ajv": "^6.5.4",
     "ajv-keywords": "^3.2.0",
     "aws-sdk": "^2.332.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react-dom": "^16.4.2"
   },
   "dependencies": {
+    "@concord-consortium/lara-plugin-api": "3.0.0-pre.2",
     "ajv": "^6.5.4",
     "ajv-keywords": "^3.2.0",
     "aws-sdk": "^2.332.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-dom": "^16.4.2"
   },
   "dependencies": {
-    "@concord-consortium/lara-plugin-api": "3.0.0-pre.3",
+    "@concord-consortium/lara-plugin-api": "3.0.0-pre.7",
     "ajv": "^6.5.4",
     "ajv-keywords": "^3.2.0",
     "aws-sdk": "^2.332.0",

--- a/src/__mocks__/@concord-consortium/lara-plugin-api.ts
+++ b/src/__mocks__/@concord-consortium/lara-plugin-api.ts
@@ -1,0 +1,33 @@
+export const registerPlugin = jest.fn();
+
+export let onWordClicked: (e: any) => null;
+export let onPopupClosed: () => null;
+export let onSidebarOpen: () => null;
+
+export const mockSidebarController = {
+  close: jest.fn()
+};
+
+export const mockPopupController = {
+  close: jest.fn()
+};
+
+export const decorateContent = jest.fn((_1: any, _2: any, _3: any, listeners: any) => {
+  // Save provided listener function.
+  onWordClicked = listeners[0].listener;
+});
+
+export const addPopup = jest.fn(options => {
+  onPopupClosed = options.onClose;
+  return mockPopupController;
+});
+
+export const addSidebar = jest.fn(options => {
+  onSidebarOpen = options.onOpen;
+  return mockSidebarController;
+});
+
+export const simulateTestWordClick = (word: string) => {
+  const event = { srcElement: { textContent: word }};
+  onWordClicked(event);
+};

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -1,14 +1,10 @@
 import { initPlugin, GlossaryPlugin } from "./plugin";
 import * as fetch from "jest-fetch-mock";
-import * as PluginAPI from "@concord-consortium/lara-plugin-api";
 (global as any).fetch = fetch;
-
 // Mock LARA API.
-jest.mock("@concord-consortium/lara-plugin-api", () => ({
-  registerPlugin: jest.fn(),
-  decorateContent: jest.fn(),
-  addSidebar: jest.fn()
-}));
+jest.mock("@concord-consortium/lara-plugin-api");
+
+import * as PluginAPI from "@concord-consortium/lara-plugin-api";
 
 describe("LARA plugin initialization", () => {
   it("loads without crashing and calls LARA.register", () => {
@@ -18,12 +14,13 @@ describe("LARA plugin initialization", () => {
 });
 
 describe("GlossaryPlugin", () => {
-  const defaultContext = {
+  const defaultContext: PluginAPI.IPluginRuntimeContext = {
     name: "test",
     url: "http://123.com",
     runId: 123,
     remoteEndpoint: null,
     userEmail: null,
+    saveLearnerPluginState: (state: string) => new Promise<string>(() => null),
     getClassInfo: () => null,
     getFirebaseJwt: (appName: string) => new Promise<PluginAPI.IJwtResponse>(() => null),
     authoredState: null,

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -73,8 +73,7 @@ export class GlossaryPlugin {
 
     this.pluginAppComponent = ReactDOM.render(
       <PluginApp
-        PluginAPI={PluginAPI}
-        pluginId={this.context.pluginId.toString()}
+        saveState={this.context.saveLearnerPluginState}
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={askForUserDefinition}

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -2,17 +2,9 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import PluginApp from "./components/plugin-app";
 import "whatwg-fetch"; // window.fetch polyfill for older browsers (IE)
+import * as PluginAPI from "@concord-consortium/lara-plugin-api";
 
-interface IExternalScriptContext {
-  div: any;
-  authoredState: string;
-  learnerState: string;
-  pluginId: string;
-}
-
-let PluginAPI: any;
-
-const getAuthoredState = async (context: IExternalScriptContext) => {
+const getAuthoredState = async (context: PluginAPI.IPluginRuntimeContext) => {
   if (!context.authoredState) {
     return {};
   }
@@ -40,7 +32,7 @@ const getAuthoredState = async (context: IExternalScriptContext) => {
   }
 };
 
-const getLearnerState = (context: IExternalScriptContext) => {
+const getLearnerState = (context: PluginAPI.IPluginRuntimeContext) => {
   const fallbackLearnerState = { definitions: {} };
   if (!context.learnerState) {
     return fallbackLearnerState;
@@ -55,10 +47,10 @@ const getLearnerState = (context: IExternalScriptContext) => {
 };
 
 export class GlossaryPlugin {
-  public context: IExternalScriptContext;
+  public context: PluginAPI.IPluginRuntimeContext;
   public pluginAppComponent: any;
 
-  constructor(context: IExternalScriptContext) {
+  constructor(context: PluginAPI.IPluginRuntimeContext) {
     this.context = context;
     // Note renderPluginApp is an async function. Constructor can't be async, as it needs to return immediately.
     // It also means that component won't be rendered immediately. That's fine.
@@ -75,14 +67,14 @@ export class GlossaryPlugin {
     const initialLearnerState = getLearnerState(this.context);
 
     if (this.pluginAppComponent) {
-      ReactDOM.unmountComponentAtNode(this.context.div);
+      ReactDOM.unmountComponentAtNode(this.context.container);
       this.pluginAppComponent = undefined;
     }
 
     this.pluginAppComponent = ReactDOM.render(
       <PluginApp
         PluginAPI={PluginAPI}
-        pluginId={this.context.pluginId}
+        pluginId={this.context.pluginId.toString()}
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={askForUserDefinition}
@@ -90,12 +82,11 @@ export class GlossaryPlugin {
       // It can be any other element in the document. Note that PluginApp render everything using React Portals.
       // It renders child components into external containers sent to LARA, not into context.div
       // or anything else that we provide here.
-      this.context.div);
+      this.context.container);
   }
 }
 
 export const initPlugin = () => {
-  PluginAPI = (window as any).LARA;
   if (!PluginAPI || !PluginAPI.registerPlugin) {
     // tslint:disable-next-line:no-console
     console.warn("LARA Plugin API not available, GlossaryPlugin terminating");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,7 +71,8 @@ module.exports = (env, argv) => {
     },
     externals: {
       'react': 'React',
-      'react-dom': 'ReactDOM'
+      'react-dom': 'ReactDOM',
+      '@concord-consortium/lara-plugin-api': 'LARA_V3'
     },
     plugins: [
       new ForkTsCheckerWebpackPlugin(),


### PR DESCRIPTION
[#165356734]

Migrate to LARA Plugin API V3 implemented in this PR:
https://github.com/concord-consortium/lara/pull/400

It's an example of how to use and configure `@concord-consortium/lara-plugin-api` package.