### PR TITLE
Add option to hide glossary sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ Run `npm test` to run all tests.
 
 ## License
 
-Teaching Teamwork is Copyright 2018 (c) by the Concord Consortium and is distributed under the [MIT license](http://www.opensource.org/licenses/MIT).
+Copyright 2018 (c) by the Concord Consortium and is distributed under the [MIT license](http://www.opensource.org/licenses/MIT).
 
 See license.md for the complete license text.

--- a/src/components/authoring/authoring-app.test.tsx
+++ b/src/components/authoring/authoring-app.test.tsx
@@ -200,6 +200,7 @@ describe("AuthoringApp component", () => {
       const glossary = {
         definitions: [{word: "test1", definition: "test 1"}],
         askForUserDefinition: false,
+        showSideBar: true
       };
 
       fetch.mockResponse(JSON.stringify(glossary));

--- a/src/components/authoring/authoring-app.test.tsx
+++ b/src/components/authoring/authoring-app.test.tsx
@@ -35,6 +35,16 @@ describe("AuthoringApp component", () => {
     expect(wrapper.find(GlossarySidebar).length).toEqual(1);
   });
 
+  describe("When `showSideBar` is unchecked", () => {
+    it("Should hide the sideBar", () => {
+      const wrapper = shallow(
+        <AuthoringApp />
+      );
+      wrapper.find("[data-cy='showSideBar']").simulate("change", { target: { checked: false }});
+      expect(wrapper.find(GlossarySidebar).length).toEqual(0);
+    });
+  });
+
   it("lets user add a new definition", () => {
     const wrapper = shallow(
       <AuthoringApp/>

--- a/src/components/authoring/authoring-app.tsx
+++ b/src/components/authoring/authoring-app.tsx
@@ -15,7 +15,7 @@ import * as icons from "../icons.scss";
 
 export const DEFAULT_GLOSSARY: IGlossary = {
   askForUserDefinition: true,
-  showSideBar: false,
+  showSideBar: true,
   definitions: []
 };
 // Keys used to obtain dat from URL or local storage.

--- a/src/components/authoring/authoring-app.tsx
+++ b/src/components/authoring/authoring-app.tsx
@@ -13,8 +13,9 @@ import { validateGlossary } from "../../utils/validate-glossary";
 import * as css from "./authoring-app.scss";
 import * as icons from "../icons.scss";
 
-export const DEFAULT_GLOSSARY = {
+export const DEFAULT_GLOSSARY: IGlossary = {
   askForUserDefinition: true,
+  showSideBar: false,
   definitions: []
 };
 // Keys used to obtain dat from URL or local storage.
@@ -62,7 +63,7 @@ export default class PluginApp extends React.Component<{}, IState> {
   public render() {
     const { newDefEditor, glossary, jsonEditorContent, definitionEditors,
       glossaryName, username, s3AccessKey, s3SecretKey, s3Status } = this.state;
-    const { askForUserDefinition, definitions } = glossary;
+    const { askForUserDefinition, definitions, showSideBar} = glossary;
     return (
       <div className={css.authoringApp}>
         <div className={css.authoringColumn}>
@@ -114,6 +115,20 @@ export default class PluginApp extends React.Component<{}, IState> {
               <div className={css.help}>
                 When this option is turned on, students will have to provide their own definition
                 before they can see an authored one.
+              </div>
+            </label>
+            <br/>
+            <input
+              type="checkbox"
+              checked={showSideBar}
+              data-cy="showSideBar"
+              onChange={this.handleShowSideBarChange}
+            />
+            <label>
+              Show Glossary icon in sidebar
+              <div className={css.help}>
+                When this option is turned on, students will have access to
+                the glossary at all times via the sidebar.
               </div>
             </label>
             <h3>Definitions</h3>
@@ -196,18 +211,26 @@ export default class PluginApp extends React.Component<{}, IState> {
         </div>
         <div className={css.preview}>
           <h2>Preview</h2>
-          <div className={css.handle}>
-            <span className={icons.iconBook}/>
-            <div>Glossary</div>
-          </div>
-          <div className={css.sidebar}>
-            <GlossarySidebar
-              definitions={definitions}
-              learnerDefinitions={{}}
-            />
-          </div>
+          {showSideBar && this.renderSideBar(definitions)}
         </div>
       </div>
+    );
+  }
+
+  public renderSideBar(definitions: IWordDefinition[]) {
+    return(
+      <div>
+        <div className={css.handle}>
+          <span className={icons.iconBook}/>
+          <div>Glossary</div>
+        </div>
+        <div className={css.sidebar}>
+          <GlossarySidebar
+            definitions={definitions}
+            learnerDefinitions={{}}
+          />
+        </div>
+    </div>
     );
   }
 
@@ -362,6 +385,12 @@ export default class PluginApp extends React.Component<{}, IState> {
   private handleAskForUserDefChange = (event: React.ChangeEvent) => {
     const glossary: IGlossary = clone(this.state.glossary);
     glossary.askForUserDefinition = (event.target as HTMLInputElement).checked;
+    this.setState({ glossary, jsonEditorContent: glossary });
+  }
+
+  private handleShowSideBarChange = (event: React.ChangeEvent) => {
+    const glossary: IGlossary = clone(this.state.glossary);
+    glossary.showSideBar = (event.target as HTMLInputElement).checked;
     this.setState({ glossary, jsonEditorContent: glossary });
   }
 

--- a/src/components/authoring/inline-authoring-form.tsx
+++ b/src/components/authoring/inline-authoring-form.tsx
@@ -11,8 +11,9 @@ import { validateGlossary } from "../../utils/validate-glossary";
 import * as css from "./authoring-app.scss";
 import * as icons from "../icons.scss";
 
-export const DEFAULT_GLOSSARY = {
+export const DEFAULT_GLOSSARY: IGlossary = {
   askForUserDefinition: true,
+  showSideBar: false,
   definitions: []
 };
 // Keys used to obtain dat from URL or local storage.
@@ -78,7 +79,7 @@ export default class InlineAuthoringForm extends React.Component<IProps, IState>
   public render() {
     const { glossary, newDefEditor, definitionEditors,
       glossaryName, username, s3AccessKey, s3SecretKey, s3Status, glossaryDirty } = this.state;
-    const { askForUserDefinition, definitions } = glossary;
+    const { askForUserDefinition, definitions, showSideBar} = glossary;
     return (
       <div className={`${css.authoringApp} ${css.inlineAuthoring}`}>
         <div className={css.scrollForm}>
@@ -151,6 +152,20 @@ export default class InlineAuthoringForm extends React.Component<IProps, IState>
                   before they can see an authored one.
                 </div>
               </label>
+              <br/>
+              <input
+                type="checkbox"
+                checked={showSideBar}
+                data-cy="showSideBar"
+                onChange={this.handleShowSideBarChange}
+              />
+              <label>
+                Show Glossary icon in sidebar
+                <div className={css.help}>
+                  When this option is turned on, students will have access to
+                  the glossary at all times via the sidebar.
+                </div>
+              </label>
               <h3>Definitions</h3>
               <table className={css.definitionsTable}>
                 <tbody>
@@ -204,16 +219,7 @@ export default class InlineAuthoringForm extends React.Component<IProps, IState>
           </div>
           <div className={css.preview}>
             <h2>Preview</h2>
-            <div className={css.handle}>
-              <span className={icons.iconBook}/>
-              <div>Glossary</div>
-            </div>
-            <div className={css.sidebar}>
-              <GlossarySidebar
-                definitions={definitions}
-                learnerDefinitions={{}}
-              />
-            </div>
+            {showSideBar && this.renderSideBar(definitions)}
           </div>
         </div>
         <div>
@@ -233,6 +239,22 @@ export default class InlineAuthoringForm extends React.Component<IProps, IState>
     );
   }
 
+  public renderSideBar(definitions: IWordDefinition[]) {
+    return(
+      <div>
+        <div className={css.handle}>
+          <span className={icons.iconBook}/>
+          <div>Glossary</div>
+        </div>
+        <div className={css.sidebar}>
+          <GlossarySidebar
+            definitions={definitions}
+            learnerDefinitions={{}}
+          />
+        </div>
+    </div>
+    );
+  }
   public get glossaryFileName() {
     const { glossaryName } = this.state;
     return glossaryName.endsWith(".json") ? glossaryName : `${glossaryName}.json`;
@@ -389,6 +411,12 @@ export default class InlineAuthoringForm extends React.Component<IProps, IState>
   private handleAskForUserDefChange = (event: React.ChangeEvent) => {
     const glossary: IGlossary = clone(this.state.glossary);
     glossary.askForUserDefinition = (event.target as HTMLInputElement).checked;
+    this.setState({ glossary });
+  }
+
+  private handleShowSideBarChange = (event: React.ChangeEvent) => {
+    const glossary: IGlossary = clone(this.state.glossary);
+    glossary.showSideBar = (event.target as HTMLInputElement).checked;
     this.setState({ glossary });
   }
 

--- a/src/components/plugin-app.test.tsx
+++ b/src/components/plugin-app.test.tsx
@@ -150,4 +150,16 @@ describe("PluginApp component", () => {
     MockPluginAPI.onSidebarOpen();
     expect(MockPluginAPI.mockPopupController.close).toHaveBeenCalledTimes(1);
   });
+  it("hides the sidebar when showSideBar is false", () => {
+    const wrapper = shallow(
+      <PluginApp
+        saveState={saveState}
+        definitions={definitions}
+        initialLearnerState={initialLearnerState}
+        askForUserDefinition={true}
+        showSideBar={false}
+      />
+    );
+    expect(wrapper.find(GlossarySidebar).length).toEqual(0);
+  });
 });

--- a/src/components/plugin-app.test.tsx
+++ b/src/components/plugin-app.test.tsx
@@ -33,6 +33,7 @@ describe("PluginApp component", () => {
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
+        showSideBar={true}
       />
     );
 
@@ -52,6 +53,7 @@ describe("PluginApp component", () => {
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
+        showSideBar={true}
       />
     );
 
@@ -74,6 +76,7 @@ describe("PluginApp component", () => {
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
+        showSideBar={true}
       />
     );
 
@@ -91,6 +94,7 @@ describe("PluginApp component", () => {
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
+        showSideBar={true}
       />
     );
 
@@ -118,6 +122,7 @@ describe("PluginApp component", () => {
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
+        showSideBar={true}
       />
     );
     expect(MockPluginAPI.addSidebar).toHaveBeenCalledTimes(1);
@@ -134,6 +139,7 @@ describe("PluginApp component", () => {
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
+        showSideBar={true}
       />
     );
 

--- a/src/components/plugin-app.tsx
+++ b/src/components/plugin-app.tsx
@@ -28,6 +28,7 @@ interface IProps {
   definitions: IWordDefinition[];
   initialLearnerState: ILearnerState;
   askForUserDefinition: boolean;
+  showSideBar: boolean;
 }
 
 interface IState {
@@ -48,7 +49,7 @@ export default class PluginApp extends React.Component<IProps, IState> {
   private sidebarController: ISidebarController;
 
   public componentDidMount() {
-    const { definitions } = this.props;
+    const { definitions, showSideBar } = this.props;
     this.definitionsByWord = {};
     definitions.forEach(entry => {
       this.definitionsByWord[entry.word.toLowerCase()] = entry;
@@ -58,7 +59,9 @@ export default class PluginApp extends React.Component<IProps, IState> {
       return;
     }
     this.decorate();
-    this.addSidebar();
+    if (showSideBar) {
+      this.addSidebar();
+    }
   }
 
   public render() {

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,5 +1,6 @@
 export interface IGlossary {
   askForUserDefinition: boolean;
+  showSideBar: boolean;
   definitions: IWordDefinition[];
 }
 

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -4,6 +4,7 @@ import PluginApp from "./components/plugin-app";
 import "whatwg-fetch"; // window.fetch polyfill for older browsers (IE)
 import * as PluginAPI from "@concord-consortium/lara-plugin-api";
 import InlineAuthoringForm from "./components/authoring/inline-authoring-form";
+import { IGlossary } from "./components/types";
 
 const getAuthoredState = async (context: PluginAPI.IPluginRuntimeContext) => {
   if (!context.authoredState) {
@@ -62,8 +63,9 @@ export class GlossaryPlugin {
   // Note that in such case it will be called twice - by constructor and by test code directly.
   // It needs to be idempotent.
   public renderPluginApp = async () => {
-    const authoredState = await getAuthoredState(this.context);
+    const authoredState: IGlossary = await getAuthoredState(this.context);
     const definitions = authoredState.definitions || [];
+    const showSideBar = authoredState.showSideBar || false;
     const askForUserDefinition = authoredState.askForUserDefinition || false;
     const initialLearnerState = getLearnerState(this.context);
 
@@ -78,6 +80,7 @@ export class GlossaryPlugin {
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={askForUserDefinition}
+        showSideBar={showSideBar}
       />,
       // It can be any other element in the document. Note that PluginApp render everything using React Portals.
       // It renders child components into external containers sent to LARA, not into context.div

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,11 @@ module.exports = (env, argv) => {
 
   return {
     context: __dirname, // to automatically find tsconfig.json
+    devServer: {
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      }
+    },
     devtool: 'source-map',
     entry: {
       demo: './src/demo.tsx',


### PR DESCRIPTION
As per [#167305438](https://www.pivotaltracker.com/n/projects/736901/stories/167305438):

Glossary authors might decide not to provide side-bar access to the glossary. 

This PR also includes a small README fix, and adds a CORS configuration for local LARA testing with webpack.