### PR TITLE
Add button tool tips for definition media buttons.

### DIFF
--- a/src/components/definition.test.tsx
+++ b/src/components/definition.test.tsx
@@ -3,6 +3,10 @@ import Definition from "./definition";
 import * as icons from "./icons.scss";
 import { shallow } from "enzyme";
 
+const expectToolTip = (wrapper: any, tip: string) => {
+  expect(wrapper.find(`[title="${tip}"]`)).toHaveLength(1);
+};
+
 describe("Definition component", () => {
   const speechSynthesisMock = {
     speak: jest.fn()
@@ -46,6 +50,7 @@ describe("Definition component", () => {
     );
     const icon = wrapper.find("." + icons.iconAudio);
     expect(icon.length).toEqual(1);
+    expectToolTip(wrapper, "Read aloud");
     icon.simulate("click");
     expect(SpeechSynthesisUtteranceMock).toHaveBeenCalledTimes(1);
     expect(speechSynthesisMock.speak).toHaveBeenCalledTimes(1);
@@ -63,6 +68,7 @@ describe("Definition component", () => {
     );
     const icon = wrapper.find("." + icons.iconImage);
     expect(icon.length).toEqual(1);
+    expectToolTip(wrapper, "View photo");
     expect(wrapper.find(`img[src='${src}']`).length).toEqual(0);
     icon.simulate("click");
     expect(wrapper.find(`img[src='${src}']`).length).toEqual(1);
@@ -83,6 +89,7 @@ describe("Definition component", () => {
     );
     const icon = wrapper.find("." + icons.iconVideo);
     expect(icon.length).toEqual(1);
+    expectToolTip(wrapper, "View movie");
     expect(wrapper.find(`video[src='${src}']`).length).toEqual(0);
     icon.simulate("click");
     expect(wrapper.find(`video[src='${src}']`).length).toEqual(1);

--- a/src/components/definition.tsx
+++ b/src/components/definition.tsx
@@ -15,6 +15,10 @@ interface IState {
   videoVisible: boolean;
 }
 
+const speechLabel = "Read aloud";
+const imageLabel  = "View photo";
+const videoLabel  = "View movie";
+
 // IE11 doesn't support this API.
 const textToSpeechAvailable = () => {
   return typeof SpeechSynthesisUtterance === "function" && typeof speechSynthesis === "object";
@@ -24,7 +28,13 @@ const renderTextToSpeech = (onClick: () => void) => {
   if (!textToSpeechAvailable()) {
     return null;
   }
-  return <span className={icons.iconButton + " " + icons.iconAudio} onClick={onClick}/>;
+  return(
+    <span
+      className={icons.iconButton + " " + icons.iconAudio}
+      onClick={onClick}
+      title={speechLabel}
+    />
+  );
 };
 
 const read = (text: string) => {
@@ -38,6 +48,32 @@ export default class Definition extends React.Component<IProps, IState> {
     videoVisible: false
   };
 
+  public renderImageButton(imageUrl?: string) {
+    if (imageUrl) {
+      return(
+        <span
+          className={icons.iconButton + " " + icons.iconImage}
+          onClick={this.toggleImage}
+          title={imageLabel}
+        />
+      );
+    }
+    return null;
+  }
+
+  public renderVideoButton(videoUrl?: string) {
+    if (videoUrl) {
+      return(
+        <span
+          className={icons.iconButton + " " + icons.iconVideo}
+          onClick={this.toggleVideo}
+          title={videoLabel}
+        />
+      );
+    }
+    return null;
+  }
+
   public render() {
     const { definition, imageUrl, videoUrl, imageCaption, videoCaption } = this.props;
     const { imageVisible, videoVisible } = this.state;
@@ -47,8 +83,8 @@ export default class Definition extends React.Component<IProps, IState> {
             {definition}
             <span className={css.icons}>
               {renderTextToSpeech(this.readDefinition)}
-              {imageUrl && <span className={icons.iconButton + " " + icons.iconImage} onClick={this.toggleImage}/>}
-              {videoUrl && <span className={icons.iconButton + " " + icons.iconVideo} onClick={this.toggleVideo}/>}
+              {this.renderImageButton(imageUrl)}
+              {this.renderVideoButton(videoUrl)}
             </span>
           </div>
         {


### PR DESCRIPTION

Glossary users need more assistance to understand Glossary functionality and need to be prompted to define words. We will include tooltips and change some label text.

* Tooltips for buttons -- Users see a tooltip over each button.
 - Read aloud, view photo, view movie

[#167978988]
https://www.pivotaltracker.com/story/show/167978988