### PR TITLE
Update "My Definition" Text

### DIFF
--- a/src/components/glossary-popup.test.tsx
+++ b/src/components/glossary-popup.test.tsx
@@ -34,6 +34,7 @@ describe("GlossaryPopup component", () => {
       const textarea = wrapper.find("textarea");
       const submit = wrapper.find("[data-cy='submit']");
       expect(textarea.length).toEqual(1);
+      expect(textarea.props().placeholder).toEqual("Write the definition in your own words here.");
       expect(submit.length).toEqual(1);
 
       const userDef = "user definition";
@@ -82,10 +83,11 @@ describe("GlossaryPopup component", () => {
 
         const reviseButton = wrapper.find("[data-cy='revise']");
         expect(reviseButton.length).toEqual(1);
-
         reviseButton.simulate("click");
+        const textarea = wrapper.find("textarea");
         expect(wrapper.text()).toEqual(expect.stringContaining(`What do you think "${word}" means?`));
         expect(wrapper.find("textarea").length).toEqual(1);
+        expect(textarea.props().placeholder).toEqual("Write your new definition in your own words here.");
         // Finds a component with given properties (UserDefinitions)
         expect(wrapper.find({userDefinitions}).length).toEqual(1);
       });

--- a/src/components/glossary-popup.tsx
+++ b/src/components/glossary-popup.tsx
@@ -107,7 +107,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
             data-cy="cancel"
             onClick={anyUserDef ? this.handleCancel : this.handleIDontKnow}
           >
-            {anyUserDef ? strings.cancel : strings.dontKnow }
+            {anyUserDef ? strings.cancel : strings.dontKnow}
           </div>
         </div>
       </div>

--- a/src/components/glossary-popup.tsx
+++ b/src/components/glossary-popup.tsx
@@ -69,12 +69,24 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
     const { word, userDefinitions } = this.props;
     const { currentUserDefinition } = this.state;
     const anyUserDef = userDefinitions && userDefinitions.length > 0;
+
+    const strings = {
+      whatDoYouThink: `What do you think "${word}" means?`,
+      writeDef:       "Write the definition in your own words here.",
+      writeNewDef:    "Write your new definition in your own words here.",
+      cancel:         "Cancel",
+      dontKnow:       "I don't know yet",
+      submit:         "Submit"
+    };
+
+    const placeholder = anyUserDef ? strings.writeNewDef : strings.writeDef;
+
     return (
       <div>
-        What do you think "{word}" means?
+        {strings.whatDoYouThink}
         <textarea
           className={css.userDefinitionTextarea}
-          placeholder="Write your definition here"
+          placeholder={placeholder}
           onChange={this.handleTextareaChange}
           value={currentUserDefinition}
         />
@@ -87,7 +99,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
         }
         <div className={css.buttons}>
           <div className={css.button} data-cy="submit" onClick={this.handleSubmit}>
-            Submit
+            {strings.submit}
           </div>
           {/* Button is different depending whether user sees the question for the fist time or not */}
           <div
@@ -95,7 +107,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
             data-cy="cancel"
             onClick={anyUserDef ? this.handleCancel : this.handleIDontKnow}
           >
-            {anyUserDef ? "Cancel" : "I don't know yet"}
+            {anyUserDef ? strings.cancel : strings.dontKnow }
           </div>
         </div>
       </div>


### PR DESCRIPTION

Glossary users need more assistance to understand Glossary functionality and need to be prompted to define words. Teachers have requested to change the wording of some elements of the glossary when students are entering their own versions of definitions.
* Replace “My definition” with “Definition in my own words”

[mocs](https://scene.zeplin.io/project/5d557b29c05f3d5241e41fba/screen/5d613e0ec572f07a7dab8538)

[#167305339]
https://www.pivotaltracker.com/story/show/167305339