### PR TITLE
Wait for Firestore auth to finish before executing queries + add security rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 dist: trusty
 language: node_js
-node_js: node
+node_js:
+  - "12"
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "jest": "^24.8.0",
     "jest-fetch-mock": "^1.7.5",
     "mini-css-extract-plugin": "^0.4.5",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.13.0",
     "npm-run-all": "^4.1.5",
     "postcss-loader": "^3.0.0",
     "react": "^16.9.0",

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -78,7 +78,7 @@ const init = async () => {
   const firebaseJWTResponse = await fetch(firebaseJWTUrl, {headers: {Authorization: getAuthHeader()}});
   const firebaseJWTRaw = await firebaseJWTResponse.json();
 
-  signInWithToken(firebaseJWTRaw.token);
+  await signInWithToken(firebaseJWTRaw.token);
 
   // Finally render Dashboard app.
   ReactDOM.render(

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,9 +5,6 @@ import { ILogEvent } from "./types";
 
 export const FIREBASE_APP = "glossary-plugin";
 
-// Useful only for manual testing Firebase rules.
-const SKIP_SIGN_IN = false;
-
 let dbInstance: firebase.firestore.Firestore | null = null;
 
 export const getFirestore = () => {
@@ -28,16 +25,12 @@ export const getFirestore = () => {
   return dbInstance;
 };
 
-export const signInWithToken = (rawFirestoreJWT: string) => {
+export const signInWithToken = async (rawFirestoreJWT: string) => {
   // Ensure firebase.initializeApp has been called.
   getFirestore();
   // It's actually useful to sign out first, as firebase seems to stay signed in between page reloads otherwise.
-  const signOutPromise = firebase.auth().signOut();
-  if (!SKIP_SIGN_IN) {
-    return signOutPromise.then(() => firebase.auth().signInWithCustomToken(rawFirestoreJWT));
-  } else {
-    return signOutPromise;
-  }
+  await firebase.auth().signOut();
+  return firebase.auth().signInWithCustomToken(rawFirestoreJWT);
 };
 
 export const settingsPath = (source: string, contextId: string, userId?: string) =>

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -82,7 +82,7 @@ export class GlossaryPlugin {
     let studentInfo;
     try {
       const firebaseJwt = await this.context.getFirebaseJwt(FIREBASE_APP);
-      signInWithToken(firebaseJwt.token);
+      await signInWithToken(firebaseJwt.token);
       studentInfo = {
         // Types in LARA Plugin API should be fixed.
         source: parseUrl((firebaseJwt.claims as IJwtClaims).domain).hostname,


### PR DESCRIPTION
Previously things were working fine, as rules were wide open... So the auth wasn't really necessary and the problem was hidden.

[#169393818]

We don't have a separate repo for Firebase project, so rules are edited in the web console.
Could you please review them too?
https://console.firebase.google.com/project/glossary-plugin/database/firestore/rules

I did little QA myself using a local instance of the plugin and things seem to work fine now.