### PR TITLE
Dashboard shows all translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ Due to the need to support translations of languages not available on poeditor.c
 | Maori (mi)        | Athabaskan      |
 | Marathi (mr)      | Inuit           |
 
+
+### Teanslations in the Dashboard (reporting)
+If you would like to limit the language selection choices in the dashboard to only languages that exist
+in the glossary definition then you can append a hash parameter to the dashboard report url in the portal.
+To specify the glossary URL in the external-report url, add  `#glossaryUrl=<uri-encoded glossary url>`
+
+This parameter name is defined as a constant in `get-url-param.tsx`
+
+```typescript
+  export const GLOSSARY_URL_PARAM = "glossaryUrl";
+```
+
+The value for this URL parameter can be viewed at the bottom of the glossary authoring interface.
+When this URL parameter exists in the dashboard url, the dashboard fetches the
+glossary definition from the glossary, and uses the `translations:` keys to find
+supported language codes.
+
+
 ## Development
 
 ### Initial steps

--- a/package-lock.json
+++ b/package-lock.json
@@ -2931,9 +2931,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "postcss": {
@@ -4236,9 +4236,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
@@ -4852,9 +4852,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5517,9 +5517,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5808,9 +5808,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
@@ -7621,9 +7621,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.camelcase": {
@@ -8021,9 +8021,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -8317,9 +8317,9 @@
       }
     },
     "node-sass": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+      "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -8329,7 +8329,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -8369,6 +8369,12 @@
             "ajv": "^6.5.5",
             "har-schema": "^2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
@@ -10231,9 +10237,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -10999,13 +11005,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },
@@ -11703,58 +11709,35 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
-      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "optional": true
         }
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-filename": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5517,9 +5517,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
-      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf dist",
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
     "lint:fix": "tslint -c tslint.json --fix 'src/**/*.{ts,tsx}'",
-    "test": "jest --detectOpenHandles",
+    "test": "jest --forceExit",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "strings:pull:usage": "echo 'Usage: npm run strings:pull -- -a <poeditor_api_key>'",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf dist",
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
     "lint:fix": "tslint -c tslint.json --fix 'src/**/*.{ts,tsx}'",
-    "test": "jest",
+    "test": "jest --detectOpenHandles",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "strings:pull:usage": "echo 'Usage: npm run strings:pull -- -a <poeditor_api_key>'",

--- a/src/components/authoring/authoring-app.scss
+++ b/src/components/authoring/authoring-app.scss
@@ -123,6 +123,17 @@
   }
 }
 
+.dashboardUrlParams {
+  background-color: #ddd;
+  color: black;
+  padding: 0.3em;
+}
+
+.s3url {
+  margin: 0.5em;
+  font-family: 'Courier New', Courier, monospace;
+}
+
 .s3Status {
   font-weight: bold;
   font-size: 0.85em;

--- a/src/components/authoring/authoring-app.test.tsx
+++ b/src/components/authoring/authoring-app.test.tsx
@@ -132,27 +132,31 @@ describe("AuthoringApp component", () => {
   // and are tested there
 
   describe(".loadJSONFromS3() method", () => {
-    it("should download data and update preview", async () => {
-      const glossary = {
-        definitions: [{word: "test1", definition: "test 1"}],
-        askForUserDefinition: false,
-        showSideBar: true
-      };
+    const glossary = {
+      definitions: [{word: "test1", definition: "test 1"}],
+      askForUserDefinition: false,
+      showSideBar: true
+    };
 
+    beforeEach(() => {
       fetch.mockResponse(JSON.stringify(glossary));
+    });
 
-      const wrapper = shallow(
-        <AuthoringApp/>
-      );
-      wrapper.setState({
-        client,
-        glossaryResource
-      });
+    it("should download data and update preview", async () => {
+      const wrapper = shallow(<AuthoringApp/>);
+      wrapper.setState({client, glossaryResource});
       await (wrapper.instance() as AuthoringApp).loadJSONFromS3();
 
       expect(fetch).toHaveBeenCalled();
       expect(wrapper.text()).toEqual(expect.stringContaining("Loading JSON: success!"));
       expect(wrapper.find(GlossarySidebar).props().definitions).toEqual(glossary.definitions);
+    });
+
+    it("Should provide the author with a glossaryUrl param to copy", async () => {
+      const wrapper = shallow(<AuthoringApp/>);
+      wrapper.setState({client, glossaryResource});
+      await (wrapper.instance() as AuthoringApp).loadJSONFromS3();
+      expect(wrapper.find("[data-cy='S3Url']").text()).toMatch("#glossaryUrl=https");
     });
   });
 

--- a/src/components/authoring/authoring-app.tsx
+++ b/src/components/authoring/authoring-app.tsx
@@ -229,7 +229,7 @@ export default class AuthoringApp extends React.Component<IProps, IState> {
       return(
         <div className={css.dashboardUrlParams}>
           Add this param to your glossary dashboard report url:
-          <div className={css.s3url}>
+          <div data-cy="S3Url" className={css.s3url}>
             #{GLOSSARY_URL_PARAM}={encodeURIComponent(publicGlossaryUrl)}
           </div>
         </div>

--- a/src/components/authoring/authoring-app.tsx
+++ b/src/components/authoring/authoring-app.tsx
@@ -197,7 +197,7 @@ export default class AuthoringApp extends React.Component<IProps, IState> {
             </div>
             <TranslationsPanel glossary={glossary} onGlossaryUpdate={this.saveGlossary} />
           </div>
-          { this.renderDashboardUrlParams() }
+          {this.renderDashboardUrlParams()}
           <div className={css.preview}>
             <h2>Preview</h2>
             {showSideBar && this.renderSideBar(definitions)}

--- a/src/components/dashboard/dashboard-app.tsx
+++ b/src/components/dashboard/dashboard-app.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
-import { IClassInfo } from "../../types";
+import { IClassInfo, IGlossary } from "../../types";
 import LanguageSelector from "./language-selector";
+import {getHashParam, GLOSSARY_URL_PARAM} from "../../utils/get-url-param";
 import StatsTableContainer from "./stats-table-container";
+import { SUPPORTED_LANGUAGES } from "../../i18n-context";
 
 import * as ccLogoSrc from "../../images/cc-logo.png";
 import * as css from "./dashboard-app.scss";
@@ -11,19 +13,60 @@ interface IProps {
   resourceUrl: string;
 }
 
-export default class DashboardApp extends React.Component<IProps, {}> {
+interface IState {
+  supportedLanguageCodes: string[];
+}
+
+export default class DashboardApp extends React.Component<IProps, IState> {
+  public state: IState = {
+    supportedLanguageCodes: SUPPORTED_LANGUAGES
+  };
+
+  public componentDidMount() {
+    this.loadGlossaryLanguages();
+  }
+
   public render() {
     const { classInfo, resourceUrl } = this.props;
+    const { supportedLanguageCodes } = this.state;
     return (
       <div className={css.dashboardApp}>
         <div className={css.header}>
           <img src={ccLogoSrc} alt="CC logo" />
         </div>
         <div className={css.content}>
-          <LanguageSelector classInfo={classInfo} />
+          <LanguageSelector classInfo={classInfo} supportedLanguageCodes={supportedLanguageCodes}/>
           <StatsTableContainer classInfo={classInfo} resourceUrl={resourceUrl} />
         </div>
       </div>
     );
+  }
+
+  // 2019-11-18 NP: If we have a URL Parameter named "glossaryUrl"
+  // we look to see which languages are defined within. Otherwise,
+  // we use the full list of SUPPORTED_LANGUAGES.
+  private loadGlossaryLanguages = () => {
+    const glossaryUrl = getHashParam(GLOSSARY_URL_PARAM);
+    const setLangs = (glossary: IGlossary) => {
+      const {translations} = glossary;
+      if (translations && Object.keys(translations).length > 0){
+        this.setState({
+          supportedLanguageCodes: Object.keys(translations)
+        });
+      }
+    };
+
+    if (glossaryUrl) {
+      fetch(glossaryUrl)
+      .then( (response: Response) => {
+        response.json().then(setLangs);
+      });
+    } else {
+      // TBD: Should we display all languages or no languages if we can't
+      // find any in the URL Params?
+      this.setState({
+        supportedLanguageCodes: SUPPORTED_LANGUAGES // []
+      });
+    }
   }
 }

--- a/src/components/dashboard/dashboard-app.tsx
+++ b/src/components/dashboard/dashboard-app.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { IClassInfo, IGlossary } from "../../types";
+import { IClassInfo } from "../../types";
 import LanguageSelector from "./language-selector";
 import {getHashParam, GLOSSARY_URL_PARAM} from "../../utils/get-url-param";
 import StatsTableContainer from "./stats-table-container";
-import { SUPPORTED_LANGUAGES } from "../../i18n-context";
+import { SUPPORTED_LANGUAGES, fetchGlossaryLanguages } from "../../i18n-context";
 
 import * as ccLogoSrc from "../../images/cc-logo.png";
 import * as css from "./dashboard-app.scss";
@@ -47,26 +47,8 @@ export default class DashboardApp extends React.Component<IProps, IState> {
   // we use the full list of SUPPORTED_LANGUAGES.
   private loadGlossaryLanguages = () => {
     const glossaryUrl = getHashParam(GLOSSARY_URL_PARAM);
-    const setLangs = (glossary: IGlossary) => {
-      const {translations} = glossary;
-      if (translations && Object.keys(translations).length > 0){
-        this.setState({
-          supportedLanguageCodes: Object.keys(translations)
-        });
-      }
-    };
-
-    if (glossaryUrl) {
-      fetch(glossaryUrl)
-      .then( (response: Response) => {
-        response.json().then(setLangs);
-      });
-    } else {
-      // TBD: Should we display all languages or no languages if we can't
-      // find any in the URL Params?
-      this.setState({
-        supportedLanguageCodes: SUPPORTED_LANGUAGES // []
-      });
-    }
+    const callback = (langCodes: string[]) =>
+      this.setState({supportedLanguageCodes: langCodes});
+    fetchGlossaryLanguages(glossaryUrl, callback);
   }
 }

--- a/src/components/dashboard/language-selector.test.tsx
+++ b/src/components/dashboard/language-selector.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { shallow, mount, ReactWrapper } from "enzyme";
+import { shallow,  ShallowWrapper } from "enzyme";
 import { getHashParam, GLOSSARY_URL_PARAM} from "../../utils/get-url-param";
 import * as fetch from "jest-fetch-mock";
 import LanguageSelector from "./language-selector";
@@ -11,60 +11,35 @@ const students = [
   {name: "student-b", id: "student-b", language: "es"},
 ];
 
-const classInfo = {
-  source: "source",
-  contextId: "context",
-  students
-};
-
-// 2019-11-19 NP: We will want to test the URL parsing too, this is a start:
-// const glossaryUrl = "http://foo.bar/index.html";
-// const glossary = {
-//   definitions: {},
-//   translations: {
-//     es: {
-//       "cloud.word": "a",
-//       "cloud.definition": "b",
-//       "cloud.image_caption": "c"
-//     }
-//   }
-// };
+const classInfo = { source: "source", contextId: "context", students };
 
 const cyTanslationsSel = "[data-cy='setTranslations']";
-
-const findLanguage = (wrapper: ReactWrapper, lang: string) => {
-  const selector = `[data-cy='language-${lang}']`;
-  expect(wrapper.find(selector).length).toEqual(1);
-};
-
-const dontFindLanguage = (wrapper: ReactWrapper, lang: string) => {
-  const selector = `[data-cy='language-${lang}']`;
-  expect(wrapper.find(selector).length).toEqual(0);
-};
+const languageSelector = (lang: string) => `[data-cy='language-${lang}']`;
 
 describe("LanguageSelector component", () => {
   describe("when languages are not specified", () => {
     it("renders all the language options", () => {
-      const wrapper = mount(
+      const wrapper = shallow(
         <LanguageSelector classInfo={classInfo} supportedLanguageCodes={SUPPORTED_LANGUAGES}/>
       );
       wrapper.find(cyTanslationsSel).simulate("click");
-      dontFindLanguage(wrapper, "en");
+      expect(wrapper.find(languageSelector("en")).length).toEqual(0);
       SUPPORTED_LANGUAGES
         .filter( l => l !== "en")
-        .forEach(l => findLanguage(wrapper, l));
+        .forEach(l => expect(wrapper.find(languageSelector(l)).length).toEqual(1));
+      expect(true).toBeTruthy();
     });
   });
 
   describe("When languages are specified", () => {
     it("renders only the language defined in the glossary", () => {
-      const wrapper = mount(
+      const wrapper = shallow(
         <LanguageSelector classInfo={classInfo} supportedLanguageCodes={["es"]}/>
       );
       wrapper.find(cyTanslationsSel).simulate("click");
-      findLanguage(wrapper, "es");
-      dontFindLanguage(wrapper, "en");
-      dontFindLanguage(wrapper, "de");
+      expect(wrapper.find(languageSelector("es")).length).toEqual(1);
+      expect(wrapper.find(languageSelector("en")).length).toEqual(0);
+      expect(wrapper.find(languageSelector("de")).length).toEqual(0);
     });
   });
 

--- a/src/components/dashboard/language-selector.test.tsx
+++ b/src/components/dashboard/language-selector.test.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import { shallow, mount, ReactWrapper } from "enzyme";
+import { getHashParam, GLOSSARY_URL_PARAM} from "../../utils/get-url-param";
+import * as fetch from "jest-fetch-mock";
+import LanguageSelector from "./language-selector";
+import {SUPPORTED_LANGUAGES} from "../../i18n-context";
+(global as any).fetch = fetch;
+
+const students = [
+  {name: "student-a", id: "student-a", language: "en"},
+  {name: "student-b", id: "student-b", language: "es"},
+];
+
+const classInfo = {
+  source: "source",
+  contextId: "context",
+  students
+};
+
+// 2019-11-19 NP: We will want to test the URL parsing too, this is a start:
+// const glossaryUrl = "http://foo.bar/index.html";
+// const glossary = {
+//   definitions: {},
+//   translations: {
+//     es: {
+//       "cloud.word": "a",
+//       "cloud.definition": "b",
+//       "cloud.image_caption": "c"
+//     }
+//   }
+// };
+
+const cyTanslationsSel = "[data-cy='setTranslations']";
+
+const findLanguage = (wrapper: ReactWrapper, lang: string) => {
+  const selector = `[data-cy='language-${lang}']`;
+  expect(wrapper.find(selector).length).toEqual(1);
+};
+
+const dontFindLanguage = (wrapper: ReactWrapper, lang: string) => {
+  const selector = `[data-cy='language-${lang}']`;
+  expect(wrapper.find(selector).length).toEqual(0);
+};
+
+describe("LanguageSelector component", () => {
+  describe("when languages are not specified", () => {
+    it("renders all the language options", () => {
+      const wrapper = mount(
+        <LanguageSelector classInfo={classInfo} supportedLanguageCodes={SUPPORTED_LANGUAGES}/>
+      );
+      wrapper.find(cyTanslationsSel).simulate("click");
+      dontFindLanguage(wrapper, "en");
+      SUPPORTED_LANGUAGES
+        .filter( l => l !== "en")
+        .forEach(l => findLanguage(wrapper, l));
+    });
+  });
+
+  describe("When languages are specified", () => {
+    it("renders only the language defined in the glossary", () => {
+      const wrapper = mount(
+        <LanguageSelector classInfo={classInfo} supportedLanguageCodes={["es"]}/>
+      );
+      wrapper.find(cyTanslationsSel).simulate("click");
+      findLanguage(wrapper, "es");
+      dontFindLanguage(wrapper, "en");
+      dontFindLanguage(wrapper, "de");
+    });
+  });
+
+});

--- a/src/components/dashboard/language-selector.tsx
+++ b/src/components/dashboard/language-selector.tsx
@@ -57,11 +57,7 @@ export default class LanguageSelector extends React.Component<IProps, IState> {
                 <tr>
                   <th />
                   {languages.map(lang =>
-                    <th
-                      key={lang}
-                      data-cy={`language-${lang}`}
-                      className={css.langName}
-                    >
+                    <th key={lang} data-cy={`language-${lang}`} className={css.langName}>
                       {langName(lang)}
                     </th>)}
                 </tr>

--- a/src/components/dashboard/language-selector.tsx
+++ b/src/components/dashboard/language-selector.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
 import { IClassInfo, IStudentSettings, IStudent, IGlossary } from "../../types";
 import { watchClassSettings, saveStudentSettings } from "../../db";
-import { getHashParam, GLOSSARY_URL_PARAM} from "../../utils/get-url-param";
-import { SUPPORTED_LANGUAGES } from "../../i18n-context";
 import { POEDITOR_LANG_NAME } from "../../utils/poeditor-language-list";
 import Button from "./button";
 import * as Modal from "react-modal";

--- a/src/i18n-context.test.ts
+++ b/src/i18n-context.test.ts
@@ -1,6 +1,16 @@
-import { defaultTranslate, replaceVariables } from "./i18n-context";
+import * as fetch from "jest-fetch-mock";
+(global as any).fetch = fetch;
+
+import {
+  defaultTranslate,
+  replaceVariables,
+  fetchGlossaryLanguages
+} from "./i18n-context";
 
 describe("pluginContext", () => {
+  afterEach(() => {
+    fetch.resetMocks();
+  });
   describe("defaultTranslate function", () => {
     it("should return English translation when available", () => {
       expect(defaultTranslate("submit", "submitFallback")).toEqual("Submit");
@@ -19,6 +29,35 @@ describe("pluginContext", () => {
       };
       const result = replaceVariables("test replaceVariables: %{var1} %{variable_321}!", variables);
       expect(result).toEqual("test replaceVariables: 123 XYZ!");
+    });
+  });
+
+  describe("fetchGlossaryLanguages(glossaryUrl, callback)", () => {
+    describe("When no glossaryUrl is provided", () => {
+      it("should return the full set of default languages", () => {
+        fetchGlossaryLanguages(null, (x) => {
+          expect(x.length).toBe(9);
+        });
+      });
+    });
+    describe("When a glossary with two translations is provided", () => {
+      const glossaryUrl = "http://foo.bar/index.html";
+      const glossary = {
+        definitions: {},
+        translations: {
+          es: { "a.word": "es-word", "a.definition": "es-desc", "a.image_caption": "es-cap" },
+          fr: { "a.word": "fr-word", "a.definition": "fr-desc", "a.image_caption": "fr-cap" }
+        }
+      };
+      beforeEach(() => {
+        fetch.mockResponse(JSON.stringify(glossary));
+      });
+      it("should only return the languages defined in the glossary at glossaryUrl", () => {
+        fetchGlossaryLanguages(glossaryUrl, (x) => {
+          expect(x).toContain("fr");
+          expect(x).toContain("en");
+        });
+      });
     });
   });
 });

--- a/src/i18n-context.test.ts
+++ b/src/i18n-context.test.ts
@@ -55,7 +55,7 @@ describe("pluginContext", () => {
       it("should only return the languages defined in the glossary at glossaryUrl", () => {
         fetchGlossaryLanguages(glossaryUrl, (x) => {
           expect(x).toContain("fr");
-          expect(x).toContain("en");
+          expect(x).toContain("es");
         });
       });
     });

--- a/src/i18n-context.ts
+++ b/src/i18n-context.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ITranslation } from "./types";
+import { ITranslation, IGlossary } from "./types";
 import * as enLang from "./lang/en.json";
 import * as esLang from "./lang/es.json";
 import * as ptLang from "./lang/pt.json";
@@ -44,6 +44,29 @@ export const defaultTranslate: ITranslateFunc = (key, fallback = null, variables
     return result;
   }
   return replaceVariables(result, variables);
+};
+
+// Check glossary at glossaryUrl for `translations` keys. If those exist
+// return them. Otherwise return `SUPPORTED_LANGUAGES` constant.
+export const fetchGlossaryLanguages = (
+  glossaryUrl: string | null,
+  callback: (languageCodes: string[]) => void) => {
+
+  const setLangs = (glossary: IGlossary) => {
+    const {translations} = glossary;
+    if (translations && Object.keys(translations).length > 0) {
+      callback(Object.keys(translations));
+    }
+  };
+
+  if (glossaryUrl) {
+    fetch(glossaryUrl)
+    .then( (response: Response) => {
+      response.json().then(setLangs);
+    });
+  } else {
+    callback(SUPPORTED_LANGUAGES);
+  }
 };
 
 export const pluginContext = React.createContext({ lang: DEFAULT_LANG, translate: defaultTranslate });

--- a/src/utils/get-url-param.tsx
+++ b/src/utils/get-url-param.tsx
@@ -9,6 +9,7 @@ function getParam(name: string, type: string): string | null {
   return decodeURIComponent(results[2].replace(/\+/g, " "));
 }
 
+export const GLOSSARY_URL_PARAM = "glossaryUrl";
 export function getQueryParam(name: string): string | null {
   return getParam(name, "?");
 }


### PR DESCRIPTION
This PR adds a new '#glossaryUrl' hash parameter to the glossary dashboards.

The hash param is displayed in a preview when in authoring mode.
Authors should add a custom report for their glossary in the portal, using this hash param.

When present the hash param limits the available languages displayed in the language selector of the dashboard to languages defined in the glossary.

Feature story:
A teacher should only see available translations for a glossary in the language settings of the dashboard.

[#169452886]
https://www.pivotaltracker.com/story/show/169452886
