### PR TITLE
Don't ask for JWT when student is not using Portal

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -113,6 +113,7 @@ describe("GlossaryPlugin", () => {
         }
       };
       const context = Object.assign({}, defaultContext, {
+        remoteEndpoint: "endpoint",
         getFirebaseJwt: (appName: string) => new Promise<PluginAPI.IJwtResponse>((resolve) => resolve(jwtResp as any))
       });
       const plugin = new GlossaryPlugin(context);

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -80,20 +80,23 @@ export class GlossaryPlugin {
     }
 
     let studentInfo;
-    try {
-      const firebaseJwt = await this.context.getFirebaseJwt(FIREBASE_APP);
-      await signInWithToken(firebaseJwt.token);
-      studentInfo = {
-        // Types in LARA Plugin API should be fixed.
-        source: parseUrl((firebaseJwt.claims as IJwtClaims).domain).hostname,
-        contextId: (firebaseJwt.claims as IJwtClaims).claims.class_hash,
-        userId: (firebaseJwt.claims as any).claims.platform_user_id.toString()
-      };
-    } catch (e) {
-      // getFirebaseJwt will throw an exception when run doesn't have remote endpoint, so when user
-      // hasn't launched an activity from Portal. In this case just do nothing special.
-      // studentInfo will be undefined and PluginApp won't try to connect to Firestore.
-      studentInfo = undefined;
+    if (this.context.remoteEndpoint) {
+      // If there's no remote endpoint, there's no connection to Portal and JWT cannot be obtained.
+      // Errors are handled anyway, but we can avoid displaying 500 error in browser console.
+      try {
+        const firebaseJwt = await this.context.getFirebaseJwt(FIREBASE_APP);
+        await signInWithToken(firebaseJwt.token);
+        studentInfo = {
+          // Types in LARA Plugin API should be fixed.
+          source: parseUrl((firebaseJwt.claims as IJwtClaims).domain).hostname,
+          contextId: (firebaseJwt.claims as IJwtClaims).claims.class_hash,
+          userId: (firebaseJwt.claims as any).claims.platform_user_id.toString()
+        };
+      } catch (e) {
+        // getFirebaseJwt will throw an exception when run doesn't have remote endpoint, so when user
+        // hasn't launched an activity from Portal. In this case just do nothing special.
+        // studentInfo will be undefined and PluginApp won't try to connect to Firestore.
+      }
     }
 
     this.pluginAppComponent = ReactDOM.render(


### PR DESCRIPTION
[#170205949]

We thought it might cause some issues. It was only log message, but we can still avoid it.

I was tempted to make this change in LARA Plugin API, and e.g. return `Promise` or `null` from `context.getFirebaseJwt`, but that would be non-backward compatible change. So, I'm not sure if it's worth it.

Also, we could consider returning JWT for users that don't have remoteEndpoint. In some cases, we could do it for sure (e.g. teacher running preview). But whether it makes sense or not, it's a separate discussion.