### PR TITLE
Display read aloud in answer placeholder, lock textarea width

### DIFF
--- a/src/components/plugin/glossary-popup.scss
+++ b/src/components/plugin/glossary-popup.scss
@@ -2,16 +2,6 @@
   font-size: 16px;
 }
 
-.userDefinitionTextarea {
-  margin-top: 20px;
-  padding: 5px;
-  width: 260px;
-  height: 80px;
-  font-size: 1em;
-  border-radius: 5px;
-  display: block;
-}
-
 .button {
   display: inline-block;
   background: #bbb;
@@ -54,5 +44,25 @@
   video {
     max-width: 256px;
     max-height: 144px
+  }
+}
+
+.answerTextarea {
+  position: relative;
+  .userDefinitionTextarea {
+    margin-top: 20px;
+    padding: 5px;
+    min-width: 260px;
+    max-width: 260px;
+    height: 80px;
+    font-size: 1em;
+    border-radius: 5px;
+    display: block;
+  }
+  span {
+    // icon
+    position: absolute;
+    bottom: 7px;
+    right: 20px;
   }
 }

--- a/src/components/plugin/glossary-popup.tsx
+++ b/src/components/plugin/glossary-popup.tsx
@@ -44,6 +44,13 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
     return i18n.translate("mainPrompt", null, { word: translatedWord, wordInEnglish: word });
   }
 
+  public get answerPlaceholder() {
+    const { userDefinitions } = this.props;
+    const i18n = this.context;
+    const anyUserDef = userDefinitions && userDefinitions.length > 0;
+    return anyUserDef ? i18n.translate("writeNewDefinition") : i18n.translate("writeDefinition");
+  }
+
   public render() {
     const { questionVisible } = this.state;
     const { secondLanguage, onLanguageChange } = this.props;
@@ -115,12 +122,18 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
         }
         {this.mainPrompt}
         <TextToSpeech text={this.mainPrompt} word={word} textType="main prompt" />
-        <textarea
-          className={css.userDefinitionTextarea}
-          placeholder={anyUserDef ? i18n.translate("writeNewDefinition") : i18n.translate("writeDefinition")}
-          onChange={this.handleTextareaChange}
-          value={currentUserDefinition}
-        />
+        <div className={css.answerTextarea}>
+          <textarea
+            className={css.userDefinitionTextarea}
+            placeholder={this.answerPlaceholder}
+            onChange={this.handleTextareaChange}
+            value={currentUserDefinition}
+          />
+          {
+            !currentUserDefinition &&
+            <TextToSpeech text={this.answerPlaceholder} word={word} textType="answer placeholder" />
+          }
+        </div>
         {
           // If user already provided some answer, display them below.
           userDefinitions && userDefinitions.length > 0 &&


### PR DESCRIPTION
[#170079515]

Width is locked, so read aloud icon is still correctly placed when user resized textarea. And changing width of the textarea looked bad anyway (user could make it wider than popup itself).