### PR TITLE
Support custom read aloud mp3 files

### DIFF
--- a/src/components/plugin/definition.tsx
+++ b/src/components/plugin/definition.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as css from "./definition.scss";
 import * as icons from "../common/icons.scss";
 import { pluginContext } from "../../plugin-context";
-import { definitionTerm, imageCaptionTerm, videoCaptionTerm } from "../../utils/translation-utils";
+import { term, TextKey } from "../../utils/translation-utils";
 import TextToSpeech from "./text-to-speech";
 
 interface IProps {
@@ -43,19 +43,19 @@ export default class Definition extends React.Component<IProps, IState> {
   public get translatedDefinition() {
     const { definition, word } = this.props;
     const translate = this.context.translate;
-    return translate(definitionTerm(word), definition);
+    return translate(term[TextKey.Definition](word), definition);
   }
 
   public get translatedImageCaption() {
     const { imageCaption, word } = this.props;
     const translate = this.context.translate;
-    return translate(imageCaptionTerm(word), imageCaption);
+    return translate(term[TextKey.ImageCaption](word), imageCaption);
   }
 
   public get translatedVideoCaption() {
     const { videoCaption, word } = this.props;
     const translate = this.context.translate;
-    return translate(videoCaptionTerm(word), videoCaption);
+    return translate(term[TextKey.VideoCaption](word), videoCaption);
   }
 
   public renderImageButton(imageUrl?: string) {
@@ -94,7 +94,7 @@ export default class Definition extends React.Component<IProps, IState> {
         <div>
           {this.translatedDefinition}
           <span className={css.icons}>
-          <TextToSpeech text={this.translatedDefinition} word={word} textType="definition" />
+          <TextToSpeech text={this.translatedDefinition} word={word} textKey={TextKey.Definition} />
           {this.renderImageButton(imageUrl)}
           {this.renderVideoButton(videoUrl)}
         </span>
@@ -107,7 +107,7 @@ export default class Definition extends React.Component<IProps, IState> {
               imageCaption &&
               <div className={css.caption}>
                 {this.translatedImageCaption}
-                <TextToSpeech text={this.translatedImageCaption} word={word} textType="image caption" />
+                <TextToSpeech text={this.translatedImageCaption} word={word} textKey={TextKey.ImageCaption} />
               </div>
             }
           </div>
@@ -120,7 +120,7 @@ export default class Definition extends React.Component<IProps, IState> {
               videoCaption &&
               <div className={css.caption}>
                 {this.translatedVideoCaption}
-                <TextToSpeech text={this.translatedVideoCaption} word={word} textType="video caption" />
+                <TextToSpeech text={this.translatedVideoCaption} word={word} textKey={TextKey.VideoCaption} />
               </div>
             }
           </div>

--- a/src/components/plugin/glossary-popup.tsx
+++ b/src/components/plugin/glossary-popup.tsx
@@ -4,7 +4,7 @@ import UserDefinitions from "./user-definitions";
 import Button from "../common/button";
 import { POEDITOR_LANG_NAME } from "../../utils/poeditor-language-list";
 import { pluginContext } from "../../plugin-context";
-import { wordTerm } from "../../utils/translation-utils";
+import { TextKey, term } from "../../utils/translation-utils";
 
 import * as css from "./glossary-popup.scss";
 import TextToSpeech from "./text-to-speech";
@@ -40,7 +40,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
   public get mainPrompt() {
     const { word } = this.props;
     const i18n = this.context;
-    const translatedWord = i18n.translate(wordTerm(word), word);
+    const translatedWord = i18n.translate(term[TextKey.Word](word), word);
     return i18n.translate("mainPrompt", null, { word: translatedWord, wordInEnglish: word });
   }
 
@@ -121,7 +121,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
           </div>
         }
         {this.mainPrompt}
-        <TextToSpeech text={this.mainPrompt} word={word} textType="main prompt" />
+        <TextToSpeech text={this.mainPrompt} word={word} textKey={TextKey.MainPrompt} />
         <div className={css.answerTextarea}>
           <textarea
             className={css.userDefinitionTextarea}
@@ -131,7 +131,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
           />
           {
             !currentUserDefinition &&
-            <TextToSpeech text={this.answerPlaceholder} word={word} textType="answer placeholder" />
+            <TextToSpeech text={this.answerPlaceholder} word={word} textKey={TextKey.WriteDefinition} />
           }
         </div>
         {

--- a/src/components/plugin/text-to-speech.test.tsx
+++ b/src/components/plugin/text-to-speech.test.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import {pluginContext} from "../../plugin-context";
+import { pluginContext } from "../../plugin-context";
 import TextToSpeech from "./text-to-speech";
 import { mount } from "enzyme";
 import * as icons from "../common/icons.scss";
+import { TextKey } from "../../utils/translation-utils";
 
 describe("TextToSpeech component", () => {
   const speechSynthesisMock = {
@@ -11,33 +12,63 @@ describe("TextToSpeech component", () => {
   const SpeechSynthesisUtteranceMock = jest.fn((text: string) => {
     return { text };
   });
+  const audioMock = {
+    play: jest.fn()
+  };
   beforeEach(() => {
     speechSynthesisMock.speak.mockClear();
     SpeechSynthesisUtteranceMock.mockClear();
+    audioMock.play.mockClear();
     (window as any).speechSynthesis = speechSynthesisMock;
     (window as any).SpeechSynthesisUtterance = SpeechSynthesisUtteranceMock;
+    (window as any).Audio = () => audioMock;
   });
 
-  it("sets correct language while reading aloud and logs click", () => {
-    const log = jest.fn();
-    const wrapper = mount(
-      <pluginContext.Provider value={{ lang: "en", translate: jest.fn(), log }}>
-        <TextToSpeech
-          text="test text"
-          word="test"
-          textType="test type"
-        />
-      </pluginContext.Provider>
-    );
+  const renderTextToSpeech = (lang: string, translate: () => string = jest.fn(), log: () => void = jest.fn()) => mount(
+    <pluginContext.Provider value={{ lang, translate, log }}>
+      <TextToSpeech
+        text="test text"
+        word="test"
+        textKey={TextKey.Definition}
+      />
+    </pluginContext.Provider>
+  );
 
+  it("renders only if there's custom mp3 or browser supports text to speech for given language", () => {
+    expect(renderTextToSpeech("en").find("." + icons.iconAudio).length).toEqual(1);
+    expect(renderTextToSpeech("gv").find("." + icons.iconAudio).length).toEqual(0); // no browser support
+    // Note that MP3 urls are provided via POEditor -> via translations
+    expect(renderTextToSpeech("gv", () => "label").find("." + icons.iconAudio).length).toEqual(0); // invalid mp3
+    expect(renderTextToSpeech("gv", () => "http://some.file.mp3").find("." + icons.iconAudio).length).toEqual(1);
+  });
+
+  it("uses provided mp3 while reading aloud and logs click", () => {
+    const log = jest.fn();
+    const translate = () => "http://some.file.mp3";
+    const wrapper = renderTextToSpeech("en", translate, log);
     wrapper.find("." + icons.iconAudio).first().simulate("click");
+    expect(speechSynthesisMock.speak).not.toHaveBeenCalled();
+    expect(audioMock.play).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith({
+      event: "text to speech clicked",
+      word: "test",
+      textType: "definition"
+    });
+  });
+
+  it("sets correct language while reading aloud using browser API and logs click", () => {
+    const log = jest.fn();
+    const wrapper = renderTextToSpeech("en", jest.fn(), log);
+    wrapper.find("." + icons.iconAudio).first().simulate("click");
+    expect(speechSynthesisMock.speak).toHaveBeenCalled();
+    expect(audioMock.play).not.toHaveBeenCalled();
     const msg = speechSynthesisMock.speak.mock.calls[0][0];
     expect(msg.text).toEqual("test text");
     expect(msg.lang).toEqual("en");
     expect(log).toHaveBeenCalledWith({
       event: "text to speech clicked",
       word: "test",
-      textType: "test type"
+      textType: "definition"
     });
   });
 });

--- a/src/utils/translation-utils.ts
+++ b/src/utils/translation-utils.ts
@@ -1,18 +1,53 @@
 import { IGlossary } from "../types";
 
-export const wordTerm = (word: string) => `${word}.word`;
-export const definitionTerm = (word: string) => `${word}.definition`;
-export const imageCaptionTerm = (word: string) => `${word}.image_caption`;
-export const videoCaptionTerm = (word: string) => `${word}.video_caption`;
+// Following languages are not supported by browser text to speech and require custom mp3 files provided by authors.
+const TEXT_TO_SPEECH_MP3_NECESSARY: {[langCode: string]: boolean} = {
+  gv: true,
+  mi: true,
+  mr: true
+};
+
+export enum TextKey {
+  Word = "word",
+  Definition = "definition",
+  ImageCaption = "imageCaption",
+  VideoCaption = "videoCaption",
+  MainPrompt = "mainPrompt",
+  WriteDefinition = "writeDefinition"
+}
+
+export const term = {
+  [TextKey.Word]: (word: string) => `${word}.word`,
+  [TextKey.Definition]: (word: string) => `${word}.definition`,
+  [TextKey.ImageCaption]: (word: string) => `${word}.image_caption`,
+  [TextKey.VideoCaption]: (word: string) => `${word}.video_caption`
+};
+
+const mp3Suffix = "_mp3_url";
+export const mp3UrlTerm = {
+  [TextKey.Word]: (word: string) => term[TextKey.Word](word) + mp3Suffix,
+  [TextKey.Definition]: (word: string) => term[TextKey.Definition](word) + mp3Suffix,
+  [TextKey.ImageCaption]: (word: string) => term[TextKey.ImageCaption](word) + mp3Suffix,
+  [TextKey.VideoCaption]: (word: string) => term[TextKey.VideoCaption](word) + mp3Suffix,
+  [TextKey.MainPrompt]: "main_prompt_mp3_url",
+  [TextKey.WriteDefinition]: "write_definition_mp3_url",
+};
 
 export const glossaryToPOEditorTerms = (glossary: IGlossary) => {
   const result: {[word: string]: string}  = {};
   glossary.definitions.forEach(def => {
-    result[wordTerm(def.word)] = def.word;
-    result[definitionTerm(def.word)] = def.definition;
-    result[imageCaptionTerm(def.word)] = def.imageCaption || "";
-    result[videoCaptionTerm(def.word)] = def.videoCaption || "";
+    result[term[TextKey.Word](def.word)] = def.word;
+    result[mp3UrlTerm[TextKey.Word](def.word)] = "[link to mp3 recording of term]";
+    result[term[TextKey.Definition](def.word)] = def.definition;
+    result[mp3UrlTerm[TextKey.Definition](def.word)] = "[link to mp3 recording of definition]";
+    result[term[TextKey.ImageCaption](def.word)] = def.imageCaption || "";
+    result[mp3UrlTerm[TextKey.ImageCaption](def.word)] = "[link to mp3 recording of image caption]";
+    result[term[TextKey.VideoCaption](def.word)] = def.videoCaption || "";
+    result[mp3UrlTerm[TextKey.VideoCaption](def.word)] = "[link to mp3 recording of video caption]";
   });
+  result[mp3UrlTerm[TextKey.MainPrompt]] = "[link to mp3 recording of 'What do you think <term> means?']";
+  result[mp3UrlTerm[TextKey.WriteDefinition]] =
+    "[link mp3 recording of 'Write the definition in your own words here.']";
   return result;
 };
 
@@ -21,18 +56,35 @@ export const isTranslationComplete = (glossary: IGlossary, langCode: string) => 
   let complete = true;
   const translation = translations![langCode];
   definitions.forEach(def => {
-    if (def.word && !translation[wordTerm(def.word)]) {
+    if (def.word && !translation[term[TextKey.Word](def.word)]) {
       complete = false;
     }
-    if (def.definition && !translation[definitionTerm(def.word)]) {
+    if (def.definition && !translation[term[TextKey.Definition](def.word)]) {
       complete = false;
     }
-    if (def.imageCaption && !translation[imageCaptionTerm(def.word)]) {
+    if (def.imageCaption && !translation[term[TextKey.ImageCaption](def.word)]) {
       complete = false;
     }
-    if (def.videoCaption && !translation[videoCaptionTerm(def.word)]) {
+    if (def.videoCaption && !translation[term[TextKey.VideoCaption](def.word)]) {
       complete = false;
     }
   });
   return complete;
+};
+
+export const getMp3Term = (textKey: TextKey, word: string) => {
+  if (typeof mp3UrlTerm[textKey] === "string") {
+    return mp3UrlTerm[textKey] as string;
+  }
+  return (mp3UrlTerm[textKey] as (word: string) => string)(word);
+};
+
+export const canUseBrowserTextToSpeech = (langCode: string) => {
+  return !TEXT_TO_SPEECH_MP3_NECESSARY[langCode];
+};
+
+export const isValidMp3Url = (url: string) => {
+  // We don't need super strict validation. Just to check if translators provided any kind of link instead of
+  // human-readable descriptions provided by default.
+  return url && url.startsWith("http");
 };


### PR DESCRIPTION
[#169843500]
[#169929326]

This PR will update exported terms to include bunch of _mp3_url fields for POEditor. Translators will have to paste there mp3 files (if they want). By default these fields include some readable description, as it's not so easy to guess which mp3 should be used for "mainPrompt" or "writeNewDefinition". Later, the code is checking if we actually use a valid URL. 

The second part of the PR updates TextToSpeech component which looks for mp3 url now and uses it if available.