### PR TITLE
Ensure that student settings can't be undefined

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -59,7 +59,7 @@ export const watchClassSettings = (
       if (snapshot.empty) {
         return;
       }
-      onSnapshot(snapshot.docs.map(d => d.data() as IStudentSettings));
+      onSnapshot(snapshot.docs.map(d => d.data()).filter(s => s) as IStudentSettings[]);
     }, (err: Error) => {
       // tslint:disable-next-line no-console
       console.error(err);
@@ -76,7 +76,10 @@ export const watchStudentSettings = (
   const db = getFirestore();
   db.collection(settingsPath(source, contextId)).doc(userId)
     .onSnapshot(snapshot => {
-      onSnapshot(snapshot.data() as IStudentSettings);
+      const data = snapshot.data();
+      if (data) {
+        onSnapshot(data as IStudentSettings);
+      }
     }, (err: Error) => {
       // tslint:disable-next-line no-console
       console.error(err);


### PR DESCRIPTION
It should fix (or hide?) this problem:
https://www.pivotaltracker.com/story/show/170205962

@scytacki, I wasn't able to replicate this issue. But looking at your error, it seems clear what can help.

I was a bit surprised that you had any settings defined, as the activity that you posted in PT story doesn't have Glossary Dashboard attached. But then I realized that settings are stored per student + class, so they're shared between activities. Probably these settings have been updated when you opened Dashboard for another activity.

I tried to look at Dashboard code too to check why we could save `undefined` and I can't really see it. We update settings just in one place, and it's always saving an object.

If you gave me your student ID etc., possibly I could track that somewhere in Firestore. But I'm not sure if it's worth it at this point unless we see some real issues (e.g. preferred language not being saved for a student or something like that).