### PR TITLE
Add inline stye to glossary replacement and IPluginEvent in wordClicked

### DIFF
--- a/src/components/plugin/plugin-app.test.tsx
+++ b/src/components/plugin/plugin-app.test.tsx
@@ -145,7 +145,7 @@ describe("PluginApp component", () => {
     expect(MockPluginAPI.decorateContent).toHaveBeenCalledTimes(1);
     expect(MockPluginAPI.decorateContent).toHaveBeenCalledWith(
       ["test", "tests"],
-      `<span class="${css.ccGlossaryWord}">$1</span>`,
+      `<span class="${css.ccGlossaryWord}" style="text-decoration:underline; cursor:pointer;">$1</span>`,
       css.ccGlossaryWord,
       [{listener: expect.any(Function), type: "click"}]
     );

--- a/src/components/plugin/plugin-app.tsx
+++ b/src/components/plugin/plugin-app.tsx
@@ -18,6 +18,7 @@ import { POEDITOR_LANG_NAME } from "../../utils/poeditor-language-list";
 export interface IPluginEvent {
   type: string;
   text: string;
+  bounds?: DOMRect;
 }
 
 interface ILearnerState {

--- a/src/components/plugin/plugin-app.tsx
+++ b/src/components/plugin/plugin-app.tsx
@@ -15,6 +15,11 @@ import * as css from "./plugin-app.scss";
 import * as icons from "../common/icons.scss";
 import { POEDITOR_LANG_NAME } from "../../utils/poeditor-language-list";
 
+export interface IPluginEvent {
+  type: string;
+  text: string;
+}
+
 interface ILearnerState {
   definitions: ILearnerDefinitions;
 }
@@ -254,7 +259,7 @@ export default class PluginApp extends React.Component<IProps, IState> {
 
   private decorate() {
     const words = Object.keys(this.state.definitionsByWord);
-    const replace = `<span class="${css.ccGlossaryWord}">$1</span>`;
+    const replace = `<span class="${css.ccGlossaryWord}" style="text-decoration:underline; cursor:pointer;">$1</span>`;
     const listener = {
       type: "click",
       listener: this.wordClicked
@@ -291,13 +296,13 @@ export default class PluginApp extends React.Component<IProps, IState> {
     });
   }
 
-  private wordClicked = (evt: Event) => {
+  private wordClicked = (evt: Event | IPluginEvent) => {
     const {definitionsByWord} = this.state;
-    const wordElement = evt.srcElement as HTMLElement;
-    if (!wordElement) {
-      return;
-    }
-    const clickedWord = (wordElement.textContent || "").toLowerCase();
+    const wordElement = "srcElement" in evt ? evt.srcElement as HTMLElement : undefined;
+    const pluginEventWord = "text" in evt ? evt.text : "";
+    const clickedWord = wordElement
+                        ? (wordElement.textContent || "").toLowerCase()
+                        : pluginEventWord.toLowerCase();
     if (!definitionsByWord[clickedWord]) {
       // Ignore, nothing to do.
       return;
@@ -314,7 +319,9 @@ export default class PluginApp extends React.Component<IProps, IState> {
         content: container,
         title: `Term: ${word}`,
         resizable: false,
-        position: { my: "left top+10", at: "left bottom", of: wordElement, collision: "flip" },
+        position: wordElement
+                  ? { my: "left top+10", at: "left bottom", of: wordElement, collision: "flip" }
+                  : undefined,
         onClose: this.popupClosed.bind(this, container)
       } );
       const newOpenPopups = openPopups.concat({ word, container, popupController });

--- a/src/components/plugin/plugin-app.tsx
+++ b/src/components/plugin/plugin-app.tsx
@@ -259,6 +259,8 @@ export default class PluginApp extends React.Component<IProps, IState> {
 
   private decorate() {
     const words = Object.keys(this.state.definitionsByWord);
+    // inline style is used so uniform style can be applied to text decoration inside iframes
+    // leave the CSS class for now, but this might become obsolete in the future
     const replace = `<span class="${css.ccGlossaryWord}" style="text-decoration:underline; cursor:pointer;">$1</span>`;
     const listener = {
       type: "click",
@@ -321,7 +323,7 @@ export default class PluginApp extends React.Component<IProps, IState> {
         resizable: false,
         position: wordElement
                   ? { my: "left top+10", at: "left bottom", of: wordElement, collision: "flip" }
-                  : undefined,
+                  : undefined, // no srcElement from the evt argument, use undefined to position in screen center
         onClose: this.popupClosed.bind(this, container)
       } );
       const newOpenPopups = openPopups.concat({ word, container, popupController });


### PR DESCRIPTION
This PR adds changes to the handling of text decoration to facilitate text decoration inside interactives in iframes in the Activity Player.  Changes includes:
- add inline CSS style to text decoration replacement string so consistent style can be applied to decorated text inside and outside iframes
- expand argument type to `wordClicked` function so it can be called from the Activity Player after receiving a message from the interactive rather than just being used as an event handler that gets passed to the text decorator.

Note: this PR is related to the LARA and Activity PRs below:
https://github.com/concord-consortium/lara/pull/664
https://github.com/concord-consortium/activity-player/pull/95