### PR TITLE
Update Firebase to use named app and to unsubscribe from watchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server --inline --hot --content-base dist/",
+    "start:secure:no-certs": "webpack-dev-server --https --inline --hot --content-base dist/",
     "build": "npm-run-all lint clean build:webpack",
     "build:webpack": "webpack --mode production --devtool false",
     "clean": "rimraf dist",


### PR DESCRIPTION
The Firebase functions were updated to use a named app instance so that it does not conflict with the Firebase app in the Activity Player.  All snapshot subscriptions are also tracked so that they can be unsubscribed to when switching pages in the activity player (which otherwise would show a console error as the snapshot would fail during signout).

 Also added secure:no-certs start script.