### PR TITLE
Fixed glossary dashboard when run against an Activity Player activity [#176896292]

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Due to the need to support translations of languages not available on poeditor.c
 | Marathi (mr)      | Inuit           |
 
 
-### Teanslations in the Dashboard (reporting)
+### Translations in the Dashboard (reporting)
 If you would like to limit the language selection choices in the dashboard to only languages that exist
 in the glossary definition then you can append a hash parameter to the dashboard report url in the portal.
 To specify the glossary URL in the external-report url, add  `#glossaryUrl=<uri-encoded glossary url>`
@@ -91,6 +91,16 @@ The value for this URL parameter can be viewed at the bottom of the glossary aut
 When this URL parameter exists in the dashboard url, the dashboard fetches the
 glossary definition from the glossary, and uses the `translations:` keys to find
 supported language codes.
+
+## Dashboard
+
+The dashboard queries events within a class (denoted by a `contextId` equal to the portal class hash) to display the dashboard data.
+The query uses the `activity_url` from the json data of the offering endpoint at the portal.  The `activity_url` is normally the
+url like  `https://authoring.concord.org/activity/<id>` however for Activity Player activities the actvity is embedded as a parameter
+within the activity url.  The code checks for the embedded activity url and extracts it as needed.
+
+**NOTE**: This activity url parsing code expects a defined format.  This code is brittle and will need to change if/when that
+format changes.
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -94,10 +94,7 @@ supported language codes.
 
 ## Dashboard
 
-The dashboard queries events within a class (denoted by a `contextId` equal to the portal class hash) to display the dashboard data.
-The query uses the `activity_url` from the json data of the offering endpoint at the portal.  The `activity_url` is normally the
-url like  `https://authoring.concord.org/activity/<id>` however for Activity Player activities the actvity is embedded as a parameter
-within the activity url.  The code checks for the embedded activity url and extracts it as needed.
+The dashboard queries events within a class (denoted by a `contextId` equal to the portal class hash) to display the dashboard data.  The query uses the `activity_url` from the json data of the offering endpoint at the portal to search the `resourceUrl` attribute in the Firestore data.  The `resourceUrl` attribute is given to the plugin as part of the context object.  The `activity_url` is normally the url like  `https://authoring.concord.org/activity/<id>` however for Activity Player activities the activity is embedded as a parameter within the activity url.  The code checks for the embedded activity url and extracts it as needed.
 
 **NOTE**: This activity url parsing code expects a defined format.  This code is brittle and will need to change if/when that
 format changes.

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -5,6 +5,7 @@ import DashboardApp from "./components/dashboard/dashboard-app";
 import { FIREBASE_APP, signInWithToken } from "./db";
 import { getQueryParam, parseUrl } from "./utils/get-url-param";
 import { IClassInfo } from "./types";
+import { extractResourceUrl } from "./utils/extract-resource-url";
 
 const getClassInfoUrl = () => getQueryParam("class");
 const getOfferingInfoUrl = () => getQueryParam("offering");
@@ -70,6 +71,7 @@ const init = async () => {
   };
   const offeringInfoResponse = await fetch(offeringUrl, {headers: {Authorization: getAuthHeader()}});
   const offeringInfoRaw = await offeringInfoResponse.json();
+  const resourceUrl = extractResourceUrl(offeringInfoRaw.activity_url);
 
   const firebaseJWTUrl = getPortalFirebaseJWTUrl(classInfo.contextId);
   if (!firebaseJWTUrl) {
@@ -84,7 +86,7 @@ const init = async () => {
   ReactDOM.render(
     <DashboardApp
       classInfo={classInfo}
-      resourceUrl={offeringInfoRaw.activity_url}
+      resourceUrl={resourceUrl}
     />
   , document.getElementById("app") as HTMLElement);
 };

--- a/src/utils/extract-resource-url.test.ts
+++ b/src/utils/extract-resource-url.test.ts
@@ -1,0 +1,15 @@
+import { extractResourceUrl } from "./extract-resource-url";
+
+describe("extract-resource-url", () => {
+  const activityUrl = "https://example.com/activities/123";
+  const activityPlayerActivityUrl =
+    "https://activity-player.concord.org/?activity=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Factivities%2F123.json";
+
+  it("handles non activity player urls", () => {
+    expect(extractResourceUrl(activityUrl)).toBe(activityUrl);
+  });
+
+  it("handles activity player urls", () => {
+    expect(extractResourceUrl(activityPlayerActivityUrl)).toBe(activityUrl);
+  });
+});

--- a/src/utils/extract-resource-url.ts
+++ b/src/utils/extract-resource-url.ts
@@ -1,0 +1,10 @@
+import { getQueryParam } from "./get-url-param";
+
+// when the glossary dashboard is launched for any activity player activity
+// the resource url needs to be pulled from the embedded query parameter and
+// the api path and the json extension removed from it
+export const extractResourceUrl = (url: string): string => {
+  const activity = getQueryParam("activity", url);
+  const matches = (activity || "").match(/^(.+)\/api\/v1\/activities\/(\d+)\.json$/);
+  return matches ? `${matches[1]}/activities/${matches[2]}` : url;
+};

--- a/src/utils/get-url-param.tsx
+++ b/src/utils/get-url-param.tsx
@@ -1,5 +1,5 @@
-function getParam(name: string, type: string): string | null {
-  const url = type === "?" ? window.location.search : window.location.hash;
+function getParam(name: string, type: string, url?: string): string | null {
+  url = url || (type === "?" ? window.location.search : window.location.hash);
   name = name.replace(/[[]]/g, "\\$&");
   const regex = new RegExp(`[${type}&]${name}(=([^&#]*)|&|#|$)`);
   const results = regex.exec(url);
@@ -10,8 +10,8 @@ function getParam(name: string, type: string): string | null {
 }
 
 export const GLOSSARY_URL_PARAM = "glossaryUrl";
-export function getQueryParam(name: string): string | null {
-  return getParam(name, "?");
+export function getQueryParam(name: string, url?: string): string | null {
+  return getParam(name, "?", url);
 }
 
 export function getHashParam(name: string): string | null {


### PR DESCRIPTION
When run against an Activity Player the activity_url in the offering info needs to be parsed to pull the activity from the activity parameter in the Activity Player url.

Here is the result when I created a temp glossary dashboard report on staging pointing to the branch with an an activity where one student defines a glossary term a couple of times:

![image](https://user-images.githubusercontent.com/112938/109164272-38d89200-7748-11eb-819a-b60072269d36.png)
