### PR TITLE
Fix failure when the first event includes bad glossary-url

### DIFF
--- a/src/i18n-context.ts
+++ b/src/i18n-context.ts
@@ -72,6 +72,10 @@ export const fetchGlossary = (
     fetch(glossaryUrl)
     .then( (response: Response) => {
       response.json().then(setLangs);
+    })
+    .catch((e) => {
+      // tslint:disable-next-line:no-console
+      console.warn(e);
     });
   } else {
     callback({languageCodes: SUPPORTED_LANGUAGES, enableRecording: false});


### PR DESCRIPTION
When loading the glossary dashboard report, if the first event pulled from FireStore had a bad Glossary URL the report would fail to load.

This PR fixes that case.