### PR TITLE
Tweaks from 4-19-2002 review

### DIFF
--- a/src/components/model-authoring/definition-form.tsx
+++ b/src/components/model-authoring/definition-form.tsx
@@ -83,7 +83,14 @@ export const DefinitionForm = (props: IProps) => {
   const renderPreview = () => {
     // disable student definition in preview so defintion is visible
     const settings: IGlossarySettings = {...props.glossary, askForUserDefinition: false}
-    return <TermPopUpPreview term={previewTerm} settings={settings} translations={props.glossary.translations || {}}/>
+    return (
+      <TermPopUpPreview
+        term={previewTerm}
+        settings={settings}
+        translations={props.glossary.translations || {}}
+        note="NOTE: This preview ignores the student-provided definitions setting in order to show the definition automatically."
+      />
+    )
   }
 
   const renderButtons = () => {

--- a/src/components/model-authoring/glossary-terms-definitions.tsx
+++ b/src/components/model-authoring/glossary-terms-definitions.tsx
@@ -41,7 +41,7 @@ interface IProps {
 
 export const GlossaryTermsDefinitions = ({ glossary, saveDefinitions }: IProps) => {
   const {definitions} = glossary
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc" | "updated">("asc")
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc" | "created"| "updated">("asc")
   const [sortedDefinitions, setSortedDefinitions] = useState<IWordDefinition[]>(definitions)
   const [modal, setModal] = useState<IModal | undefined>(undefined)
 
@@ -77,6 +77,7 @@ export const GlossaryTermsDefinitions = ({ glossary, saveDefinitions }: IProps) 
     checkUpdatedDefinition(newDefinition, errors, true)
 
     if (Object.keys(errors).length === 0) {
+      newDefinition.createdAt = Date.now()
       newDefinition.updatedAt = Date.now()
       const newDefinitions = definitions.slice()
       newDefinitions.push(newDefinition)
@@ -220,13 +221,17 @@ export const GlossaryTermsDefinitions = ({ glossary, saveDefinitions }: IProps) 
   useEffect(() => {
     const sorted = definitions.slice()
     sorted.sort((a, b) => {
+      let result: number
       switch (sortOrder) {
         case "asc":
           return a.word.localeCompare(b.word)
         case "desc":
           return b.word.localeCompare(a.word)
+        case "created":
+          result = (b.createdAt || 0) - (a.createdAt || 0)
+          return result || a.word.localeCompare(b.word)
         case "updated":
-          const result = (b.updatedAt || 0) - (a.updatedAt || 0)
+          result = (b.updatedAt || 0) - (a.updatedAt || 0)
           return result || a.word.localeCompare(b.word)
       }
     })
@@ -250,6 +255,7 @@ export const GlossaryTermsDefinitions = ({ glossary, saveDefinitions }: IProps) 
             <select value={sortOrder} onChange={handleSortOrder}>
               <option value="asc">A to Z</option>
               <option value="desc">Z to A</option>
+              <option value="created">Newest</option>
               <option value="updated">Most Recently Updated</option>
             </select>
           </div>

--- a/src/components/model-authoring/glossary-translations.tsx
+++ b/src/components/model-authoring/glossary-translations.tsx
@@ -250,7 +250,7 @@ export const GlossaryTranslations = ({ glossary, lang, usedLangs, saveTranslatio
             <select value={sortOrder} onChange={handleSortOrder}>
               <option value="asc">A to Z</option>
               <option value="desc">Z to A</option>
-              <option value="untranslated">Most Untranslated</option>
+              <option value="untranslated">Needs translation</option>
             </select>
           </div>
         </div>

--- a/src/components/model-authoring/language-settings-form.tsx
+++ b/src/components/model-authoring/language-settings-form.tsx
@@ -98,13 +98,13 @@ export const LanguageSettingsForm = (props: IProps) => {
             </div>
           </div>
           <div className={css.fieldset}>
-            <legend>Main Prompt MP3 Url</legend>
+            <legend>Main Prompt MP3 URL</legend>
             <div>
             <input type="text" name="mainPromptMP3Url" defaultValue={getTranslatedValue("mainPromptMP3Url")} placeholder={`MP3 recording of translated main prompt instructions`} />
             </div>
           </div>
           <div className={css.fieldset}>
-            <legend>Write Definition MP3 Url</legend>
+            <legend>Write Definition MP3 URL</legend>
             <div>
             <input type="text" name="writeDefinitionMP3Url" defaultValue={getTranslatedValue("writeDefinitionMP3Url")} placeholder={`MP3 recording of translated write definition instructions`} />
             </div>

--- a/src/components/model-authoring/model-authoring-app.scss
+++ b/src/components/model-authoring/model-authoring-app.scss
@@ -24,6 +24,7 @@
 
     .rightColumn {
       width: 25%;
+      min-width: 340px;
     }
   }
 

--- a/src/components/model-authoring/term-popup-preview.scss
+++ b/src/components/model-authoring/term-popup-preview.scss
@@ -1,27 +1,35 @@
-.outerPopup {
-  margin: 20px 0;
-  align-self: center;
-  background-color: white;
-  width: 300px;
-  color: #313131;
-  border: solid #0592af;
+.termPopupPreview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 
-  .header {
-    display: flex;
-    justify-content: space-between;
-    padding: 8px;
-    background-color: #cdebf2;
+  .outerPopup {
+    margin: 20px 0;
+    align-self: center;
+    background-color: white;
+    width: 300px;
+    color: #313131;
+    border: solid #0592af;
 
-    h4 {
-      margin: 0px;
+    .header {
+      display: flex;
+      justify-content: space-between;
+      padding: 8px;
+      background-color: #cdebf2;
+
+      h4 {
+        margin: 0px;
+      }
     }
 
-    .exit {
-      color: #0592af;
+    .innerPopup {
+      padding: 10px;
     }
   }
 
-  .innerPopup {
-    padding: 10px;
+  .note {
+    width: 300px;
+    font-style: italic;
   }
 }

--- a/src/components/model-authoring/term-popup-preview.tsx
+++ b/src/components/model-authoring/term-popup-preview.tsx
@@ -13,10 +13,11 @@ interface IProps {
   translations: ITranslationMap;
   term: IWordDefinition
   lang?: string
+  note?: string
 }
 
 export const TermPopUpPreview = (props: IProps) => {
-  const { term, settings, translations } = props;
+  const { term, settings, translations, note } = props;
   const [lang, setLang] = useState(props.lang || "en")
   const [languages, setLanguages] = useState<ILanguage[]>([])
   const [userDefinitions, setUserDefinitions] = useState<string[]>([]);
@@ -65,29 +66,31 @@ export const TermPopUpPreview = (props: IProps) => {
 
   return (
     <pluginContext.Provider value={{ lang, translate: translatePreview, log }} key={renderUpdateCount}>
-      <div className={css.outerPopup}>
-        <div className={css.header}>
-          <h4>Term: {term.word}</h4>
-          <h4 className={css.exit}>X</h4>
+      <div className={css.termPopupPreview}>
+        <div className={css.outerPopup}>
+          <div className={css.header}>
+            <h4>Term: {term.word}</h4>
+          </div>
+          <div className={css.innerPopup}>
+            <GlossaryPopup
+              word={term.word}
+              definition={term.definition}
+              imageUrl={term.image}
+              imageCaption={term.imageCaption}
+              zoomImageUrl={term.zoomImage}
+              videoUrl={term.video}
+              videoCaption={term.videoCaption}
+              languages={languages}
+              onLanguageChange={onLanguageChange}
+              askForUserDefinition={settings.askForUserDefinition}
+              enableStudentRecording={settings.enableStudentRecording}
+              autoShowMedia={settings.autoShowMediaInPopup}
+              userDefinitions={settings.askForUserDefinition ? userDefinitions : []}
+              onUserDefinitionsUpdate={onUserDefinitionsUpdate}
+            />
+          </div>
         </div>
-        <div className={css.innerPopup}>
-          <GlossaryPopup
-            word={term.word}
-            definition={term.definition}
-            imageUrl={term.image}
-            imageCaption={term.imageCaption}
-            zoomImageUrl={term.zoomImage}
-            videoUrl={term.video}
-            videoCaption={term.videoCaption}
-            languages={languages}
-            onLanguageChange={onLanguageChange}
-            askForUserDefinition={settings.askForUserDefinition}
-            enableStudentRecording={settings.enableStudentRecording}
-            autoShowMedia={settings.autoShowMediaInPopup}
-            userDefinitions={settings.askForUserDefinition ? userDefinitions : []}
-            onUserDefinitionsUpdate={onUserDefinitionsUpdate}
-          />
-        </div>
+        {note && <div className={css.note}>{note}</div>}
       </div>
     </pluginContext.Provider>
   )

--- a/src/components/model-authoring/translation-form.tsx
+++ b/src/components/model-authoring/translation-form.tsx
@@ -151,19 +151,19 @@ export const TranslationForm = (props: IProps) => {
             </div>
           </div>
           <div className={css.fieldset}>
-            <legend>Definition MP3 Url</legend>
+            <legend>Definition MP3 URL</legend>
             <div>
             <input type="text" name="translatedDefinitionMP3Url" defaultValue={getTranslatedValue("translatedDefinitionMP3Url")} placeholder={`MP3 recording of translated definition for ${word}`} />
             </div>
           </div>
           <div className={css.fieldset}>
-            <legend>Image Caption MP3 Url</legend>
+            <legend>Image Caption MP3 URL</legend>
             <div>
             <input type="text" name="translatedImageCaptionMP3Url" defaultValue={getTranslatedValue("translatedImageCaptionMP3Url")} placeholder={`MP3 recording of translated image caption for ${word}`} />
             </div>
           </div>
           <div className={css.fieldset}>
-            <legend>Video Caption MP3 Url</legend>
+            <legend>Video Caption MP3 URL</legend>
             <div>
             <input type="text" name="translatedVideoCaptionMP3Url" defaultValue={getTranslatedValue("translatedVideoCaptionMP3Url")} placeholder={`MP3 recording of translated video caption for ${word}`} />
             </div>

--- a/src/components/model-authoring/translation-table.tsx
+++ b/src/components/model-authoring/translation-table.tsx
@@ -50,8 +50,8 @@ export const TranslationTable = ({lang, translations, definitions, onDelete, onE
           <th>Term</th>
           <th>Translated Term</th>
           <th className={css.definition}>Translated Definition</th>
-          <th>Image</th>
-          <th>Video</th>
+          <th>Image Caption</th>
+          <th>Video Caption</th>
           <th className={css.actions}>&nbsp;</th>
         </tr>
       </thead>

--- a/src/hooks/use-migrate-glossary.ts
+++ b/src/hooks/use-migrate-glossary.ts
@@ -17,7 +17,12 @@ export const useMigrateGlossary = (initialGlossary: IGlossary, updateGlossary: (
     glossaryChanged = true
   }
 
+  // use the term position in the array as a proxy for the created at and updated at times since new terms are added to the end of the array
   glossary.definitions.forEach((definition, index) => {
+    if (!definition.createdAt) {
+      definition.createdAt = index + 1;
+      glossaryChanged = true;
+    }
     if (!definition.updatedAt) {
       definition.updatedAt = index + 1;
       glossaryChanged = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface IWordDefinition {
   video?: string;
   imageCaption?: string;
   videoCaption?: string;
+  createdAt?: number;
   updatedAt?: number;
 }
 


### PR DESCRIPTION
- Removed X from sidebar preview
- Updated “most untranslated” to Needs translations
- Added a note to authors to let them know that edit preview doesn’t show what students see if definitions are required
- Updated "Url" to "URL" everywhere
- Updated Image & Video headers to Image Caption and Video Caption in the translations table
- Added a "Newest" option to the sort by on terms