### PR TITLE
Ensure glossary api protocol matches window protocol [#181889116]

### DIFF
--- a/src/components/model-authoring/model-authoring-app.tsx
+++ b/src/components/model-authoring/model-authoring-app.tsx
@@ -65,15 +65,10 @@ const ModelAuthoringApp = ({demo, apiUrl, initialData}: IProps) => {
     setUsedLangs(langs);
   }, [glossary]);
 
-  return (
-    <div className={css.modelAuthoringApp}>
-      <div className={css.header}>
-        <h1>Edit Glossary: {name}</h1>
-        <SaveIndicator status={saveIndicatorStatus} />
-        {demo && saveInDemo && <div className={css.clearDemoData}><button onClick={handleClearSavedDemoData}>Clear Saved Demo Data</button></div>}
-      </div>
-      <div className={css.columns}>
-        <div className={css.leftColumn}>
+  const renderLeftColumn = () => {
+    if (glossary.definitions) {
+      return (
+        <>
           <GlossaryTermsDefinitions glossary={glossary} saveDefinitions={saveDefinitions}/>
           <AddTranslation glossary={glossary} saveTranslations={saveTranslations}/>
           {usedLangs.map(lang => (
@@ -84,6 +79,21 @@ const ModelAuthoringApp = ({demo, apiUrl, initialData}: IProps) => {
               saveTranslations={saveTranslations}
               usedLangs={usedLangs}
             />))}
+        </>
+      )
+    }
+  }
+
+  return (
+    <div className={css.modelAuthoringApp}>
+      <div className={css.header}>
+        <h1>Edit Glossary: {name}</h1>
+        <SaveIndicator status={saveIndicatorStatus} />
+        {demo && saveInDemo && <div className={css.clearDemoData}><button onClick={handleClearSavedDemoData}>Clear Saved Demo Data</button></div>}
+      </div>
+      <div className={css.columns}>
+        <div className={css.leftColumn}>
+          {renderLeftColumn()}
         </div>
         <div className={css.rightColumn}>
           <GlossarySettings name={name} glossary={glossary} saveSettings={saveSettings} saveName={updateName}/>

--- a/src/hooks/use-save.ts
+++ b/src/hooks/use-save.ts
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { saveInDemo } from "../components/model-authoring/params";
 import { IGlossary } from "../types";
+import ensureCorrectProtocol from "../utils/ensure-correct-protocol";
 
 export interface ISaveIndicatorSaving {
   mode: "saving";
@@ -50,8 +51,8 @@ export const useSave = (options: { demo?: boolean; apiUrl?: string; }) => {
       setTimeout(() => updateSaveIndicator({ mode: "saved" }), 1000);
     } else if (apiUrl) {
       try {
-        const response = await fetch(apiUrl, {
-          method: "POST",
+        const response = await fetch(ensureCorrectProtocol(apiUrl), {
+          method: "PUT",
           headers: {
             "Content-Type": "application/json",
           },

--- a/src/i18n-context.ts
+++ b/src/i18n-context.ts
@@ -9,6 +9,7 @@ import * as gvLang from "./lang/gv.json";
 import * as miLang from "./lang/mi.json";
 import * as mrLang from "./lang/mr.json";
 import * as zhCNLang from "./lang/zh-CN.json";
+import ensureCorrectProtocol from "./utils/ensure-correct-protocol";
 
 type ITranslateFunc = (key: string, fallback?: string | null, variables?: {[key: string]: string}) => string | null;
 
@@ -85,7 +86,7 @@ export const fetchGlossary = (
   };
 
   if (glossaryUrl) {
-    fetch(glossaryUrl)
+    fetch(ensureCorrectProtocol(glossaryUrl))
     .then( (response: Response) => {
       response.json().then(setLangs);
     })

--- a/src/utils/ensure-correct-protocol.test.ts
+++ b/src/utils/ensure-correct-protocol.test.ts
@@ -1,0 +1,29 @@
+import ensureCorrectProtocol from "./ensure-correct-protocol";
+
+describe("ensureCorrectProtocol", () => {
+  const win = {
+    location: {
+      protocol: "https:"
+    }
+  } as Window
+
+  it("handles http urls and http windows", () => {
+    win.location.protocol = "http:"
+    expect(ensureCorrectProtocol("http://example.com/test", win)).toBe("http://example.com/test")
+  })
+
+  it("handles http urls and https windows", () => {
+    win.location.protocol = "https:"
+    expect(ensureCorrectProtocol("http://example.com/test", win)).toBe("https://example.com/test")
+  })
+
+  it("handles https urls and http windows", () => {
+    win.location.protocol = "http:"
+    expect(ensureCorrectProtocol("https://example.com/test", win)).toBe("https://example.com/test")
+  })
+
+  it("handles https urls and https windows", () => {
+    win.location.protocol = "https:"
+    expect(ensureCorrectProtocol("https://example.com/test", win)).toBe("https://example.com/test")
+  })
+})

--- a/src/utils/ensure-correct-protocol.ts
+++ b/src/utils/ensure-correct-protocol.ts
@@ -1,0 +1,16 @@
+// ensures that if the window protocol is https the url protocol is set to https
+const ensureCorrectProtocol = (url: string, win?: Window) => {
+  try {
+    const parsedUrl = new URL(url)
+
+    if ((win || window).location.protocol === "https:") {
+      parsedUrl.protocol = "https:"
+    }
+
+    return parsedUrl.toString()
+  } catch (e) {
+    return url
+  }
+}
+
+export default ensureCorrectProtocol

--- a/src/utils/usage-stats-helpers.test.ts
+++ b/src/utils/usage-stats-helpers.test.ts
@@ -31,11 +31,11 @@ describe("usage statistic helpers", () => {
 
   describe("#getGlossaryJSON", () => {
     it("should fetch glossary JSON and cache it for later use", async () => {
-      expect(await getGlossaryJSON("http://s3.url/glossary/123.json")).toEqual(glossary);
-      expect(fetch).toHaveBeenCalledWith("http://s3.url/glossary/123.json");
+      expect(await getGlossaryJSON("https://s3.url/glossary/123.json")).toEqual(glossary);
+      expect(fetch).toHaveBeenCalledWith("https://s3.url/glossary/123.json");
       expect(fetch).toHaveBeenCalledTimes(1);
 
-      expect(await getGlossaryJSON("http://s3.url/glossary/123.json")).toEqual(glossary);
+      expect(await getGlossaryJSON("https://s3.url/glossary/123.json")).toEqual(glossary);
       expect(fetch).toHaveBeenCalledTimes(1); // still 1
     });
   });
@@ -127,7 +127,7 @@ describe("usage statistic helpers", () => {
       const sId = "123";
       const students = [ { id: sId }  ] as IStudent[];
       const events = [
-        { userId: sId, event: "plugin init", glossaryUrl: "http://glossary.com" },
+        { userId: sId, event: "plugin init", glossaryUrl: "https://glossary.com" },
         { userId: sId, event: "term clicked", word: "cloud" },
         { userId: sId, event: "definition saved", word: "cloud", definitions: [ "foo", "bar" ] },
         { userId: sId, event: "image icon clicked", word: "cloud" },
@@ -147,7 +147,7 @@ describe("usage statistic helpers", () => {
       const sId = "123";
       const students = [ { id: sId }  ] as IStudent[];
       const events = [
-        { userId: sId, event: "plugin init", glossaryUrl: "http://glossary.com" },
+        { userId: sId, event: "plugin init", glossaryUrl: "https://glossary.com" },
         { userId: sId, event: "term clicked", word: "cloud" },
         { userId: sId, event: "term clicked", word: "eardrum" },
       ] as ILogEvent[];

--- a/src/utils/usage-stats-helpers.ts
+++ b/src/utils/usage-stats-helpers.ts
@@ -1,4 +1,5 @@
 import { IGlossary, IStudent, ILogEvent } from "../types";
+import ensureCorrectProtocol from "./ensure-correct-protocol";
 
 export interface ISupportsDef {
   textToSpeech: boolean;
@@ -67,7 +68,7 @@ export const resetGlossaryInstance = () => glossaryInstance = null;
 export const getGlossaryJSON = async (glossaryUrl: string): Promise<IGlossary|null> => {
   if (!glossaryInstance) {
     try {
-      const response = await fetch(glossaryUrl);
+      const response = await fetch(ensureCorrectProtocol(glossaryUrl));
       glossaryInstance = await response.json();
     }
     // tslint:disable-next-line:no-console


### PR DESCRIPTION
Since the api protocol is generated inside a Docker container that doesn't know what protocol may be proxying the requests this change ensures the api url protocol matches the window that the authoring or plugin is embedded within.

This also fixes an issue seen when integrating into Lara - the definitions and translations are null on the initial load of a new glossary so the rendering needs to be made conditional until the migration hook updates the json.