### PR TITLE
Add missing credentials in glossary save

### DIFF
--- a/src/hooks/use-save.ts
+++ b/src/hooks/use-save.ts
@@ -57,6 +57,7 @@ export const useSave = (options: { demo?: boolean; apiUrl?: string; }) => {
             "Content-Type": "application/json",
           },
           body: JSON.stringify(body),
+          credentials: "include"
         });
         const json = await response.json();
         updateSaveIndicator({ mode: "saved" });


### PR DESCRIPTION
This missing cookie causes authentiation to fail