### PR TITLE
Adding digging deeper columns to definitions and translations tables [#181853373] [#181853227]

### DIFF
--- a/src/components/model-authoring/definition-table.tsx
+++ b/src/components/model-authoring/definition-table.tsx
@@ -32,7 +32,7 @@ export const DefinitionTableRow = (props: IDefinitionTableRowProps) => {
   const {canEdit} = props;
   const handleDelete = () => props.onDelete(props.definition);
   const handleEdit = () => props.onEdit(props.definition);
-  const { word, definition, image, video } = props.definition;
+  const { word, definition, diggingDeeper, image, video } = props.definition;
 
   const handleImageClick = () => props.onImageClick(props.definition);
   const handleVideoClick = () => props.onVideoClick(props.definition);
@@ -47,6 +47,7 @@ export const DefinitionTableRow = (props: IDefinitionTableRowProps) => {
     <tr key={word}>
       <td>{word}</td>
       <td>{definition}</td>
+      <td className={css.centered}>{(diggingDeeper || "").length > 0 ? "✓" : ""}</td>
       <td className={css.centered}>{(image || "").length > 0 ? <span className={imageSpanClassName} onClick={handleImageClick}>{imageButton}</span> : undefined}</td>
       <td className={css.centered}>{(video || "").length > 0 ? <span className={videoSpanClassName} onClick={handleVideoClick}>{videoButton}</span> : undefined}</td>
       <td className={css.actions}>
@@ -67,13 +68,14 @@ interface IDefinitionTableProps {
   onVideoClick: (definition: IWordDefinition) => void;
 }
 
-export const DefinitionTable = ({ definitions, modal, canEdit, onDelete, onEdit, onImageClick, onVideoClick }: IDefinitionTableProps) => {
+export const DefinitionTable = ({ definitions, modal, canEdit, onDelete, onEdit, onImageClick, onVideoClick}: IDefinitionTableProps) => {
   return (
     <table className={css.sharedTable}>
       <thead>
         <tr>
           <th>Term</th>
           <th className={css.definition}>Definition</th>
+          <th>Digging Deeper</th>
           <th>Image</th>
           <th>Video</th>
           <th className={css.actions}>&nbsp;</th>

--- a/src/components/model-authoring/glossary-translations.tsx
+++ b/src/components/model-authoring/glossary-translations.tsx
@@ -42,8 +42,10 @@ export interface ITranslatedWordDefinition extends IWordDefinition {
   translatedVideoCaptionMP3Url: string;
   hasImageCaption: boolean;
   hasVideoCaption: boolean;
+  hasDiggingDeeper: boolean;
   hasTranslatedImageCaption: boolean;
   hasTranslatedVideoCaption: boolean;
+  hasTranslatedDiggingDeeper: boolean;
   translationRank: number;
 }
 
@@ -187,8 +189,10 @@ export const GlossaryTranslations = ({ glossary, lang, usedLangs, canEdit, saveT
       const hasTranslatedDefinition = translatedDefinition.length > 0
       const hasImageCaption = (definition.imageCaption || "").length > 0
       const hasVideoCaption = (definition.videoCaption || "").length > 0
+      const hasDiggingDeeper = (definition.diggingDeeper || "").length > 0
       const hasTranslatedImageCaption = translatedImageCaption.length > 0
       const hasTranslatedVideoCaption = translatedVideoCaption.length > 0
+      const hasTranslatedDiggingDeeper = translatedDiggingDeeper.length > 0
 
       let translationRank = 0
       if (hasTranslatedWord) { translationRank++ }
@@ -211,8 +215,10 @@ export const GlossaryTranslations = ({ glossary, lang, usedLangs, canEdit, saveT
         translatedVideoCaptionMP3Url,
         hasImageCaption,
         hasVideoCaption,
+        hasDiggingDeeper,
         hasTranslatedImageCaption,
         hasTranslatedVideoCaption,
+        hasTranslatedDiggingDeeper,
         translationRank
       }
     })

--- a/src/components/model-authoring/translation-table.tsx
+++ b/src/components/model-authoring/translation-table.tsx
@@ -19,13 +19,14 @@ export const TranslationTableRow = (props: ITranslationTableRowProps) => {
   const {canEdit} = props
   const handleDelete = () => props.onDelete(props.definition);
   const handleEdit = () => props.onEdit(props.definition);
-  const { word, translatedWord, translatedDefinition, hasTranslatedImageCaption, hasImageCaption, hasTranslatedVideoCaption, hasVideoCaption } = props.definition;
+  const { word, translatedWord, translatedDefinition, hasTranslatedImageCaption, hasImageCaption, hasTranslatedVideoCaption, hasVideoCaption, hasTranslatedDiggingDeeper, hasDiggingDeeper } = props.definition;
 
   return (
     <tr key={word}>
       <td>{word}</td>
       <td>{translatedWord}</td>
       <td>{translatedDefinition}</td>
+      <td className={css.centered}>{hasTranslatedDiggingDeeper ? "✓" : (hasDiggingDeeper ? "✗" : "")}</td>
       <td className={css.centered}>{hasTranslatedImageCaption ? "✓" : (hasImageCaption ? "✗" : "")}</td>
       <td className={css.centered}>{hasTranslatedVideoCaption ? "✓" : (hasVideoCaption ? "✗" : "")}</td>
       <td className={css.actions}>
@@ -53,6 +54,7 @@ export const TranslationTable = ({lang, translations, definitions, canEdit, onDe
           <th>Term</th>
           <th>Translated Term</th>
           <th className={css.definition}>Translated Definition</th>
+          <th>Digging Deeper</th>
           <th>Image Caption</th>
           <th>Video Caption</th>
           <th className={css.actions}>&nbsp;</th>


### PR DESCRIPTION
As per conversation with Kiley, currently definitions table just displays a checkmark if there is a Digging Deeper definition associated with the term. I think it would be great if we could use the Digging Deeper SVG icon and use formatting similar to image / video for consistency. Will bring up tomorrow.