### PR TITLE
Added UI to directly edit the glossary json [#181937147]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,29 @@ E.g.:
 - https://glossary-plugin.concord.org/version/1.0.0/plugin.js
 - https://glossary-plugin.concord.org/version/1.1.0/plugin.js
 
-## Authoring page
+
+## New Authoring
+
+**TODO** Update this section, tracked in this story: https://www.pivotaltracker.com/story/show/181972724
+
+### Query Parameters
+
+There are a few query query parameters that are checked in the glossary model authoring:
+
+1. `dangerouslyEditJson` - when this is `true` a textarea is shown at the top of the page that allows
+direct edits of the glossary JSON.  As noted by the parameter name this can be dangerous as no validation
+is done other than to validate it parses as JSON.  This will be used to port over existing glossaries.
+NOTE: the JSON shown is the initial glossary JSON, any updates done in the UI are not reflected in the
+textarea.
+
+2. `debugJson` - when this is `true` a div is shown at the bottom of the page with a static view of the
+JSON.  This is useful for debugging.
+
+3. `saveInDemo` - when this is `true` in the `model-authoring-demo.html` url any changes made in the demo
+are saved in localstorage and then re-read on page load.  This is useful for development.
+
+## Old Authoring
+### Authoring page
 
 https://glossary-plugin.concord.org/authoring.html
 
@@ -29,7 +51,7 @@ https://console.aws.amazon.com/iam/home#/groups/Glossary-S3-Access
 
 It limits access to their own directory based on the username (IAM username and username on the authoring page have to match).
 
-## Authored state format
+### Authored state format
 
 Authoring page UI should always generate a correct JSON. Existing format example:
 
@@ -61,11 +83,11 @@ Note that you can define glossary inline or specify URL to a JSON that contains 
 }
 ```
 
-## Translations
+### Translations
 
 Translations are stored in JSON files in the `src/lang` folder are managed using poeditor.com.  To add new strings update the `en.json` file and run `npm run strings:push` after running `export POEDITOR_API_TOKEN=<TOKEN>` where `<TOKEN>` can be found under your user settings in poeditor.com.  To pull down translations run  `npm run strings:pull` after exporting the api token.
 
-### Translation Mappings
+#### Translation Mappings
 
 Due to the need to support translations of languages not available on poeditor.com we have coopted existing languages we don't plan to use and mapped them to the unsupported languages.  Here is the current mapping:
 
@@ -76,7 +98,7 @@ Due to the need to support translations of languages not available on poeditor.c
 | Marathi (mr)      | Inupiaq         |
 
 
-### Translations in the Dashboard (reporting)
+#### Translations in the Dashboard (reporting)
 If you would like to limit the language selection choices in the dashboard to only languages that exist
 in the glossary definition then you can append a hash parameter to the dashboard report url in the portal.
 To specify the glossary URL in the external-report url, add  `#glossaryUrl=<uri-encoded glossary url>`

--- a/src/components/model-authoring/dangerously-edit-json.scss
+++ b/src/components/model-authoring/dangerously-edit-json.scss
@@ -1,0 +1,16 @@
+.dangerouslyEditJson {
+  margin: 10px 0;
+  padding: 10px;
+  background-color: red;
+
+  div {
+    color: white;
+    font-weight: bold;
+  }
+
+  textarea {
+    width: 100%;
+    height: 300px;
+    margin: 10px 0;
+  }
+}

--- a/src/components/model-authoring/dangerously-edit-json.tsx
+++ b/src/components/model-authoring/dangerously-edit-json.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { useRef } from "react";
+import { IGlossary } from "../../types";
+
+import * as css from "./dangerously-edit-json.scss";
+
+interface IProps {
+  glossary: IGlossary;
+  saveGlossary: (glossary: IGlossary) => void;
+}
+
+export const DangerouslyEditJson = ({ glossary, saveGlossary }: IProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSave = () => {
+    try {
+      const newGlossary = JSON.parse(textareaRef.current?.value || "{}");
+      saveGlossary(newGlossary);
+    } catch (e) {
+      alert(`Error parsing JSON: ${e.message}`);
+    }
+  }
+
+  return (
+    <div className={css.dangerouslyEditJson}>
+      <div>DANGEROUS! Only use this if you know what you are doing. No validation is done to ensure the JSON is correct when saved!</div>
+      <textarea defaultValue={JSON.stringify(glossary, null, 2)} ref={textareaRef} />
+      <button onClick={handleSave}>Save Edited JSON</button>
+    </div>
+  )
+}

--- a/src/components/model-authoring/model-authoring-app.tsx
+++ b/src/components/model-authoring/model-authoring-app.tsx
@@ -8,12 +8,13 @@ import { GlossaryTermsDefinitions } from "./glossary-terms-definitions";
 import { GlossarySettings } from "./glossary-settings";
 import { useSave } from "../../hooks/use-save";
 import { useMigrateGlossary } from "../../hooks/use-migrate-glossary";
-import { debugJson, saveInDemo } from "./params";
+import { debugJson, saveInDemo, dangerouslyEditJson } from "./params";
 import {demoGlossary} from "./demo-glossary"
 import { AddTranslation, allLanguages } from "./add-translation";
 import { GlossaryTranslations } from "./glossary-translations";
 
 import * as css from "./model-authoring-app.scss";
+import { DangerouslyEditJson } from "./dangerously-edit-json";
 
 interface IProps {
   demo?: boolean;
@@ -96,6 +97,7 @@ const ModelAuthoringApp = ({demo, apiUrl, initialData}: IProps) => {
         {demo && saveInDemo && <div className={css.clearDemoData}><button onClick={handleClearSavedDemoData}>Clear Saved Demo Data</button></div>}
       </div>
       {!canEdit && <div className={css.readonlyGlossaryNotice}>You are not the author of this glossary so any changes you make will not be reflected in the UI or saved.</div>}
+      {dangerouslyEditJson && <DangerouslyEditJson glossary={glossary} saveGlossary={updateGlossary}/>}
       <div className={css.columns}>
         <div className={css.leftColumn}>
           {renderLeftColumn()}

--- a/src/components/model-authoring/params.ts
+++ b/src/components/model-authoring/params.ts
@@ -1,5 +1,6 @@
 const params = new URLSearchParams(window.location.search);
 const debugJson = params.has("debugJson") === true;
 const saveInDemo = params.has("saveInDemo") === true;
+const dangerouslyEditJson = params.has("dangerouslyEditJson") === true;
 
-export { debugJson, saveInDemo };
+export { debugJson, saveInDemo, dangerouslyEditJson };


### PR DESCRIPTION
This has already been reviewed (https://github.com/concord-consortium/glossary-plugin/pull/130) but got merged into the wrong branch (a chained branch that already had been merged into new-sections).