### PR TITLE
Fixed variable replacement in Arabic translation [#182014957]

### DIFF
--- a/src/i18n-context.test.ts
+++ b/src/i18n-context.test.ts
@@ -31,6 +31,13 @@ describe("pluginContext", () => {
       const result = replaceVariables("test replaceVariables: %{var1} %{variable_321}!", variables);
       expect(result).toEqual("test replaceVariables: 123 XYZ!");
     });
+
+    it("should work in right to left languages", () => {
+      const arabic = require("../src/lang/ar.json");
+      const result = replaceVariables(arabic.mainPrompt, {word: "test"});
+      expect(arabic.mainPrompt).toEqual("ما رأيك \"%{word}\" تعني؟");
+      expect(result).toEqual("ما رأيك \"test\" تعني؟");
+    });
   });
 
   describe("fetchGlossaryLanguages(glossaryUrl, callback)", () => {

--- a/src/lang/ar.json
+++ b/src/lang/ar.json
@@ -1,5 +1,5 @@
 {
-    "mainPrompt": "ما رأيك \"{word}%\" تعني؟",
+    "mainPrompt": "ما رأيك \"%{word}\" تعني؟",
     "submit": "تقديم",
     "cancel": "إلغاء",
     "iDontKnowYet": "أنا لا أعرف حتى الآن",


### PR DESCRIPTION
The percent marker needs to be left to right even in a right to left language.