### PR TITLE
Added optional reset term popup preview button [#182054556]

### DIFF
--- a/src/components/model-authoring/glossary-settings.tsx
+++ b/src/components/model-authoring/glossary-settings.tsx
@@ -163,7 +163,13 @@ export const GlossarySettings = ({ name, glossary, canEdit, saveSettings, saveNa
           </div>
         </div>
 
-        <TermPopUpPreview term={previewTerm} settings={glossary} translations={previewTranslations} />
+        <TermPopUpPreview
+          term={previewTerm}
+          settings={glossary}
+          translations={previewTranslations}
+          allowReset={true}
+          resetLabel="Reset Term Popup Preview"
+        />
       </div>
     </Panel>
   )

--- a/src/components/model-authoring/term-popup-preview.tsx
+++ b/src/components/model-authoring/term-popup-preview.tsx
@@ -14,10 +14,12 @@ interface IProps {
   term: IWordDefinition
   lang?: string
   note?: string
+  allowReset?: boolean
+  resetLabel?: string
 }
 
 export const TermPopUpPreview = (props: IProps) => {
-  const { term, settings, translations, note } = props;
+  const { term, settings, translations, note, allowReset, resetLabel } = props;
   const [lang, setLang] = useState(props.lang || "en")
   const [languages, setLanguages] = useState<ILanguage[]>([])
   const [userDefinitions, setUserDefinitions] = useState<string[]>([]);
@@ -38,6 +40,12 @@ export const TermPopUpPreview = (props: IProps) => {
 
   const onUserDefinitionsUpdate = (userDefinition: string) => {
     setUserDefinitions([...userDefinitions, userDefinition]);
+  }
+
+  const onReset = () => {
+    setUserDefinitions([]);
+    onLanguageChange(props.lang || "en");
+    forceReRender();
   }
 
   // increment this on each settings update to force a re-render as this is used as the top level key
@@ -94,6 +102,7 @@ export const TermPopUpPreview = (props: IProps) => {
           </div>
         </div>
         {note && <div className={css.note}>{note}</div>}
+        {allowReset && <button className={css.resetButton} onClick={onReset}>{resetLabel || "Reset"}</button>}
       </div>
     </pluginContext.Provider>
   )


### PR DESCRIPTION
This is currently only used for the preview in the settings sidebar.