### PR TITLE
Fixed bugs in translations table & modal [#182062833]

### DIFF
--- a/src/components/model-authoring/definition-table.tsx
+++ b/src/components/model-authoring/definition-table.tsx
@@ -75,7 +75,7 @@ export const DefinitionTable = ({ definitions, modal, canEdit, onDelete, onEdit,
         <tr>
           <th>Term</th>
           <th className={css.definition}>Definition</th>
-          <th>Digging Deeper</th>
+          <th className={css.centered}>Digging Deeper</th>
           <th>Image</th>
           <th>Video</th>
           <th className={css.actions}>&nbsp;</th>

--- a/src/components/model-authoring/shared-table.scss
+++ b/src/components/model-authoring/shared-table.scss
@@ -15,11 +15,15 @@ table.sharedTable {
 
       padding: 5px;
       text-align: left;
+      vertical-align: middle;
       color: #333;
       font-weight: 100;
       font-size: 0.9rem;
-      white-space: nowrap;
       border-right: 1px solid #777;
+
+      &.centered {
+        text-align: center;
+      }
 
       &.definition {
         width: 100%;
@@ -35,7 +39,7 @@ table.sharedTable {
     tr {
       font-size: 14px;
     }
-    
+
     tr:hover {
       background-color: #ddd !important;
     }

--- a/src/components/model-authoring/translation-form.tsx
+++ b/src/components/model-authoring/translation-form.tsx
@@ -51,6 +51,7 @@ export const TranslationForm = (props: IProps) => {
       [mp3UrlTerm[TextKey.Definition](word)]: getFormValue("translatedDefinitionMP3Url"),
       [mp3UrlTerm[TextKey.ImageCaption](word)]: getFormValue("translatedImageCaptionMP3Url"),
       [mp3UrlTerm[TextKey.VideoCaption](word)]: getFormValue("translatedVideoCaptionMP3Url"),
+      [mp3UrlTerm[TextKey.DiggingDeeper](word)]: getFormValue("translatedDiggingDeeperMP3Url"),
     }
     return newTranslation
   }

--- a/src/components/model-authoring/translation-table.tsx
+++ b/src/components/model-authoring/translation-table.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-import { translate } from "../../i18n-context";
 import { ITranslationMap, IWordDefinition } from "../../types";
-import { term, TextKey } from "../../utils/translation-utils";
 import { ITranslatedWordDefinition } from "./glossary-translations";
 
 import * as css from "./shared-table.scss";
@@ -52,11 +50,11 @@ export const TranslationTable = ({lang, translations, definitions, canEdit, onDe
       <thead>
         <tr>
           <th>Term</th>
-          <th>Translated Term</th>
+          <th className={css.centered}>Translated Term</th>
           <th className={css.definition}>Translated Definition</th>
-          <th>Digging Deeper</th>
-          <th>Image Caption</th>
-          <th>Video Caption</th>
+          <th className={css.centered}>Digging Deeper</th>
+          <th className={css.centered}>Image Caption</th>
+          <th className={css.centered}>Video Caption</th>
           <th className={css.actions}>&nbsp;</th>
         </tr>
       </thead>


### PR DESCRIPTION
1. Wrapped all headers and vertically and horizontally aligned them
2. Fixed save of digging deeper mp3 url field
3. Add stop of recorded mp3s and stop of all text to speech when component is unmounted

**NOTE:** there is one more bug about the translation fields not being saved when the language is changed but it is resistant to being squashed.  I will create a new PR for that tomorrow.