### PR TITLE
Enabled audio recording in preview [#182054608]

### DIFF
--- a/src/components/model-authoring/term-popup-preview.tsx
+++ b/src/components/model-authoring/term-popup-preview.tsx
@@ -81,6 +81,7 @@ export const TermPopUpPreview = (props: IProps) => {
           </div>
           <div className={css.innerPopup}>
             <GlossaryPopup
+              demoMode={true}
               word={term.word}
               definition={term.definition}
               diggingDeeper={term.diggingDeeper}

--- a/src/components/plugin/glossary-popup.test.tsx
+++ b/src/components/plugin/glossary-popup.test.tsx
@@ -258,8 +258,8 @@ describe("GlossaryPopup component", () => {
     const mockAlert = jest.fn().mockImplementation((text) => console.log("ALERT", text));
     const mockMediaRecorderStart = jest.fn();
     let mockedMediaRecorder: any = null;
-    // tslint:disable-next-line:no-console
     const mockMediaRecorderStop = jest.fn().mockImplementation(() => mockedMediaRecorder.onstop());
+    const mockedMediaRecorderIsTypeSupported = jest.fn().mockImplementation(() => true);
     const MockedMediaRecorder = jest.fn();
     MockedMediaRecorder.mockImplementation(() => {
       mockedMediaRecorder = {
@@ -268,6 +268,9 @@ describe("GlossaryPopup component", () => {
       };
       return mockedMediaRecorder;
     });
+    // isTypeSupported is a static method of MediaRecorder
+    (MockedMediaRecorder as any).isTypeSupported = mockedMediaRecorderIsTypeSupported;
+
     let mockedFileReader: any = null;
     const fakeAudioUrl = "data:audio/mp3;base64,FOO";
     const MockedFileReader = jest.fn();
@@ -317,6 +320,7 @@ describe("GlossaryPopup component", () => {
       const recordButton = wrapper.find("[data-cy='recordButton']");
       await recordButton.simulate("click");
       expect(mockMediaRecorderStart).toBeCalled();
+      expect(mockedMediaRecorderIsTypeSupported).toBeCalledWith("audio/webm");
     });
 
     it("sets the current user definition with an audio url when the stop button is pressed", async () => {

--- a/src/components/plugin/glossary-popup.tsx
+++ b/src/components/plugin/glossary-popup.tsx
@@ -435,7 +435,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
     navigator.mediaDevices.getUserMedia({ audio: true })
       .then(stream => {
         this.updateRecording({nextState: RecordingState.Recording, clearRecording: true});
-        this.mediaRecorder = new MediaRecorder(stream);
+        this.mediaRecorder = new MediaRecorder(stream, {mimeType: "audio/webm"});
         this.mediaRecorder.ondataavailable = (event) => {
           this.recordedBlobs.push(event.data);
         };

--- a/src/components/plugin/glossary-popup.tsx
+++ b/src/components/plugin/glossary-popup.tsx
@@ -435,7 +435,9 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
     navigator.mediaDevices.getUserMedia({ audio: true })
       .then(stream => {
         this.updateRecording({nextState: RecordingState.Recording, clearRecording: true});
-        this.mediaRecorder = new MediaRecorder(stream, {mimeType: "audio/webm"});
+        // find the first supported audio format in the order of most supported cross browser
+        const audioMimeType = ["audio/webm", "audio/mpeg", "audio/mp4", "audio/ogg"].find(m => MediaRecorder.isTypeSupported(m));
+        this.mediaRecorder = new MediaRecorder(stream, {mimeType: audioMimeType});
         this.mediaRecorder.ondataavailable = (event) => {
           this.recordedBlobs.push(event.data);
         };


### PR DESCRIPTION
- Passed demo flag to popup so that is uses existing faked upload of audio
- Added explict audio mimetype as the existing blank mimetype was returning octet-stream blobs instead of audio blobs.  The mimetype used is the first one found that is supported in a list of common audio mimetypes, sorted by cross browser support.