### PR TITLE
Added hide of modal glossary preview for small screens [#182071820]

### DIFF
--- a/src/components/model-authoring/shared-modal-form.scss
+++ b/src/components/model-authoring/shared-modal-form.scss
@@ -114,6 +114,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: auto;
   }
 
   button {
@@ -124,4 +125,12 @@
     align-self: auto;
   }
 
+}
+
+@media only screen and (max-width: 950px)  {
+  .modalForm {
+    .right {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
When the user's screen is narrow the modal was overflowing the screen.  Scrollbars really wouldn't work well in that situation so the preview is hidden with a screen width less than 950px.