### PR TITLE
Fixed missing runtime plugin options [#182114134]

### DIFF
--- a/src/components/plugin/plugin-app.test.tsx
+++ b/src/components/plugin/plugin-app.test.tsx
@@ -47,6 +47,7 @@ describe("PluginApp component", () => {
         enableStudentRecording={false}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -76,6 +77,7 @@ describe("PluginApp component", () => {
         enableStudentRecording={false}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -106,6 +108,7 @@ describe("PluginApp component", () => {
         enableStudentRecording={false}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -132,6 +135,7 @@ describe("PluginApp component", () => {
         enableStudentRecording={false}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -160,6 +164,7 @@ describe("PluginApp component", () => {
         translations={{}}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -186,6 +191,7 @@ describe("PluginApp component", () => {
         translations={{}}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -215,6 +221,7 @@ describe("PluginApp component", () => {
         translations={{}}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -239,6 +246,7 @@ describe("PluginApp component", () => {
         translations={{}}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -263,6 +271,7 @@ describe("PluginApp component", () => {
         translations={{}}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -297,6 +306,7 @@ describe("PluginApp component", () => {
         translations={{}}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
     expect(MockPluginAPI.addSidebar).toHaveBeenCalledTimes(1);
@@ -320,6 +330,7 @@ describe("PluginApp component", () => {
         translations={{}}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
 
@@ -345,6 +356,7 @@ describe("PluginApp component", () => {
         translations={{}}
         offlineMode={false}
         enableStudentLanguageSwitching={false}
+        showIDontKnowButton={false}
       />
     );
     expect(wrapper.find(GlossarySidebar).length).toEqual(0);
@@ -365,6 +377,7 @@ describe("PluginApp component", () => {
           translations={{}}
           offlineMode={false}
           enableStudentLanguageSwitching={false}
+          showIDontKnowButton={false}
         />
       );
       const pluginApp: PluginApp = (wrapper.instance() as PluginApp);
@@ -391,6 +404,7 @@ describe("PluginApp component", () => {
           }}
           offlineMode={false}
           enableStudentLanguageSwitching={false}
+          showIDontKnowButton={false}
         />
       );
       const pluginApp: PluginApp = (wrapper.instance() as PluginApp);

--- a/src/components/plugin/plugin-app.tsx
+++ b/src/components/plugin/plugin-app.tsx
@@ -56,6 +56,7 @@ interface IProps {
   resourceUrl?: string;
   laraLog?: (event: string | PluginAPI.ILogData) => void;
   offlineMode: boolean;
+  showIDontKnowButton: boolean;
 }
 
 export interface IDefinitionsByWord {
@@ -150,7 +151,7 @@ export default class PluginApp extends React.Component<IProps, IState> {
   }
 
   public render() {
-    const { askForUserDefinition, autoShowMediaInPopup, definitions, studentInfo, disableReadAloud } = this.props;
+    const { askForUserDefinition, autoShowMediaInPopup, definitions, studentInfo, disableReadAloud, showIDontKnowButton } = this.props;
     const { openPopups, learnerState, sidebarPresent, lang, definitionsByWord } = this.state;
     // student recording is enabled per student with the combination of it being enabled by the glossary
     // author along with it being enabled by the teacher in the dashboard per student
@@ -210,6 +211,9 @@ export default class PluginApp extends React.Component<IProps, IState> {
                   languages={this.languages}
                   onLanguageChange={this.languageChanged}
                   studentInfo={studentInfo}
+                  disableReadAloud={disableReadAloud}
+                  showIDontKnowButton={showIDontKnowButton}
+                  diggingDeeper={glossaryItem.diggingDeeper}
                 />,
                 container
               );

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -3,11 +3,8 @@ import * as ReactDOM from "react-dom";
 import PluginApp from "./components/plugin/plugin-app";
 import "whatwg-fetch"; // window.fetch polyfill for older browsers (IE)
 import * as PluginAPI from "@concord-consortium/lara-plugin-api";
-import { FIREBASE_APP, signInWithToken } from "./db";
 import AuthoringApp, { IGlossaryAuthoredState } from "./components/authoring/authoring-app";
 import { IGlossary, IGlossaryModelAuthoringInfo } from "./types";
-import { IJwtClaims } from "@concord-consortium/lara-plugin-api";
-import { parseUrl } from "./utils/get-url-param";
 import { syncLogEventsToFirestore, setStudentInfo } from "./components/plugin/offline-storage";
 import { getStudentInfo } from "./utils/get-student-info";
 import { renderGlossaryModelAuthoring } from "./components/model-authoring/model-authoring-app";
@@ -109,6 +106,7 @@ export class GlossaryPlugin {
         resourceUrl={this.context.resourceUrl}
         laraLog={this.context.log}
         offlineMode={this.context.offlineMode}
+        showIDontKnowButton={authoredState.showIDontKnowButton || false}
       />,
       // It can be any other element in the document. Note that PluginApp render everything using React Portals.
       // It renders child components into external containers sent to LARA, not into context.div


### PR DESCRIPTION
These options were not being passed to the runtime plugin:

- Display “I Don’t Know” button
- Disable read-aloud buttons
- Digging deeper icon