### PR TITLE
Fixed multiple file upload field setting [#181946122]

### DIFF
--- a/src/components/model-authoring/definition-form.tsx
+++ b/src/components/model-authoring/definition-form.tsx
@@ -68,11 +68,10 @@ export const DefinitionForm = (props: IProps) => {
     }
   }
 
-  const handleFieldChange = useCallback((field: IWordDefinitionKey) => {
-    return (e: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>) => {
-      setDefinition({...definition, [field]: e.target.value})
-    }
-  }, [definition])
+  const handleFieldChange = (field: IWordDefinitionKey) => {
+    return (e: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>) =>
+      setDefinition((prev) => ({...prev, [field]: e.target.value}))
+  }
 
   const renderPreview = () => {
     // disable student definition in preview so definition is visible

--- a/src/components/model-authoring/translation-form.tsx
+++ b/src/components/model-authoring/translation-form.tsx
@@ -99,11 +99,10 @@ export const TranslationForm = (props: IProps) => {
     return <TermPopUpPreview key={`${lang}-${word}`} term={props.translatedDefinition} settings={settings} translations={previewTranslations} lang={lang}/>
   }
 
-  const handleFieldChange = useCallback((field: ITranslatedWordDefinitionKey) => {
-    return (e: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>) => {
-      setTranslation({...translation, [field]: e.target.value})
-    }
-  }, [translation])
+  const handleFieldChange = (field: ITranslatedWordDefinitionKey) => {
+    return (e: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>) =>
+      setTranslation((prev) => ({...prev, [field]: e.target.value}));
+  }
 
   const renderButtons = () => {
     if (canEdit) {


### PR DESCRIPTION
This actually a general fix for both the definition and translation forms.  Before the field change handler was wrapped in a useCallback but this failed when multiple uploads were in flight.  The change is to remove the useCallback and change the translation setter to use the callback form.  This ensures that the current translation object is always updated instead of the one captured by the useCallback function wrapper.