### PR TITLE
Fixed enable student recording setting not being used in preview runtime [#182358089]

### DIFF
--- a/src/components/plugin/plugin-app.tsx
+++ b/src/components/plugin/plugin-app.tsx
@@ -142,11 +142,15 @@ export default class PluginApp extends React.Component<IProps, IState> {
             enableStudentRecording: enableRecording
            });
         }));
-
-        this.log({
-          event: "plugin init"
-        });
+      } else {
+        // default student recording to true - it then must also be set in the glossary settings
+        // for it to be enabled in the user interface
+        this.setState({enableStudentRecording: true});
       }
+
+      this.log({
+        event: "plugin init"
+      });
     });
   }
 


### PR DESCRIPTION
Prior to this change the enableStudentRecording was always false when used in preview mode as only the per-student setting in the glossary dashboard enabled it.

NOTE: this also fixes the plugin init logging when running in preview mode.