### PR TITLE
Digging deeper fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "webpack-dev-server": "^4.7.4"
   },
   "peerDependencies": {
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "dependencies": {
     "@concord-consortium/lara-plugin-api": "3.3.1",

--- a/src/components/plugin/definition.tsx
+++ b/src/components/plugin/definition.tsx
@@ -104,8 +104,10 @@ export default class Definition extends React.Component<IProps, IState> {
     return null;
   }
 
-  public renderDiggingDeeperButton(diggingDeeper?: string) {
-    if (diggingDeeper) {
+  public renderDiggingDeeperButton() {
+    // Check translatedDiggingDeeper instead of diggingDeeper prop, so the button is still shown when Digging Deeper
+    // is not defined for English, but it's defined for currently selected language.
+    if (this.translatedDiggingDeeper) {
       const translate = this.context.translate;
       return(
         <span
@@ -129,7 +131,7 @@ export default class Definition extends React.Component<IProps, IState> {
             {!disableReadAloud && <TextToSpeech text={this.translatedDefinition} word={word} textKey={TextKey.Definition} />}
             {this.renderImageButton(imageUrl)}
             {this.renderVideoButton(videoUrl)}
-            {this.renderDiggingDeeperButton(diggingDeeper)}
+            {this.renderDiggingDeeperButton()}
           </span>
         </div>}
         { diggingDeeperVisible &&


### PR DESCRIPTION
[#182704055]

Note that this will still show the digging deeper button in the secondary language, even if digging deeper is not defined in this language. It'll use English as a fallback. This seems to be a pattern across the whole UI (eg image captions will fallback to English too).