### PR TITLE
Add option to display second language first (PT-186345829)

### DIFF
--- a/src/components/authoring/authoring-app.tsx
+++ b/src/components/authoring/authoring-app.tsx
@@ -24,6 +24,7 @@ export const DEFAULT_GLOSSARY: IGlossary = {
   showIDontKnowButton: false,
   enableStudentRecording: false,
   enableStudentLanguageSwitching: false,
+  showSecondLanguageFirst: false,
   definitions: []
 };
 

--- a/src/components/authoring/translations-panel.test.tsx
+++ b/src/components/authoring/translations-panel.test.tsx
@@ -30,6 +30,7 @@ const defGlossary: IGlossary = {
   disableReadAloud: false,
   enableStudentRecording: false,
   enableStudentLanguageSwitching: false,
+  showSecondLanguageFirst: false,
   translations: {
     es: {
       "cloud.word": "a",
@@ -118,6 +119,7 @@ describe("TranslationsPanel component", () => {
       disableReadAloud: false,
       enableStudentRecording: false,
       enableStudentLanguageSwitching: false,
+      showSecondLanguageFirst: false,
       translations: {
         es: {
           "cloud.word": "a",

--- a/src/components/model-authoring/demo-glossary.ts
+++ b/src/components/model-authoring/demo-glossary.ts
@@ -12,6 +12,7 @@ export const demoGlossary: IGlossaryModelAuthoringInitialData = {
     enableStudentLanguageSwitching: false,
     disableReadAloud: false,
     enableStudentRecording: false,
+    showSecondLanguageFirst: false,
     definitions: [
       {
         "word": "cluster housing",

--- a/src/components/model-authoring/glossary-settings.scss
+++ b/src/components/model-authoring/glossary-settings.scss
@@ -36,18 +36,6 @@
       padding-left: 10px;
       padding-right: 10px;
     }
-
-    .dropDown {
-      display: flex;
-      flex-direction: column;
-      label {
-        margin-top: 5px;
-      }
-      select {
-        margin-top: 5px;
-        align-self: flex-start;
-      }
-    }
   }
 
   .nestedOptions {

--- a/src/components/model-authoring/glossary-settings.scss
+++ b/src/components/model-authoring/glossary-settings.scss
@@ -36,6 +36,18 @@
       padding-left: 10px;
       padding-right: 10px;
     }
+
+    .dropDown {
+      display: flex;
+      flex-direction: column;
+      label {
+        margin-top: 5px;
+      }
+      select {
+        margin-top: 5px;
+        align-self: flex-start;
+      }
+    }
   }
 
   .nestedOptions {

--- a/src/components/model-authoring/glossary-settings.tsx
+++ b/src/components/model-authoring/glossary-settings.tsx
@@ -38,7 +38,7 @@ const previewTranslations: ITranslationMap = {
 
 export const GlossarySettings = ({ name, glossary, canEdit, saveSettings, saveName }: IProps) => {
   const { askForUserDefinition, showSideBar, autoShowMediaInPopup, showIDontKnowButton, enableStudentRecording,
-    disableReadAloud, showSecondLanguageFirst, secondLanguageCode, translations } = glossary;
+    disableReadAloud, showSecondLanguageFirst, translations } = glossary;
   const [enabled, setEnabled] = useState<boolean>(askForUserDefinition);
 
   const handleUserDefinitionChange = () => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -53,19 +53,7 @@ export const GlossarySettings = ({ name, glossary, canEdit, saveSettings, saveNa
   }
 
   const handleChange = (setting: keyof IGlossarySettings ) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    // clear second language if showSecondLanguageFirst is disabled
-    if (setting === "showSecondLanguageFirst" && !e.target.checked) {
-      saveSettings({...glossary, [setting]: e.target.checked, "secondLanguageCode": undefined});
-    } else if (setting === "showSecondLanguageFirst" && e.target.checked && translations) {
-      const secondLang = Object.keys(translations)[0];
-      saveSettings({...glossary, [setting]: e.target.checked, "secondLanguageCode": secondLang});
-    } else {
       saveSettings({...glossary, [setting]: e.target.checked});
-    }
-  }
-
-  const handleSecondLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    saveSettings({...glossary, "secondLanguageCode": e.target.value});
   }
 
   return (
@@ -162,24 +150,9 @@ export const GlossarySettings = ({ name, glossary, canEdit, saveSettings, saveNa
             </label>
           </div>
           <div className={css.help}>
-            When this option is enabled, students will see the selected secondary language first in the term popup.
+            When this option is enabled, students will see their assigned second language first in the term popup.
+            Second language is set per student by the teacher via the Glossary Dashboard in the Portal.
           </div>
-          { showSecondLanguageFirst &&
-            <div className={css.dropDown}>
-              <label>Select Second Language</label>
-              <select
-                value={secondLanguageCode}
-                onChange={handleSecondLanguageChange}
-              >
-                {translations && Object.keys(translations).map(lang => {
-                    const langName = allLanguages[lang as keyof typeof allLanguages];
-                    return (
-                      <option key={lang} value={lang}>{langName}</option>
-                    );
-                })}
-              </select>
-            </div>
-          }
         </div>
 
         <div className={css.settingInformation}>

--- a/src/components/plugin/language-selector-button.scss
+++ b/src/components/plugin/language-selector-button.scss
@@ -17,7 +17,7 @@
     color: #fff;
   }
 
-  &.en{
+  &.firstLang{
     border-radius: 5px 0px 0px 5px;
     border-width: 1px;
   }

--- a/src/components/plugin/language-selector-button.tsx
+++ b/src/components/plugin/language-selector-button.tsx
@@ -8,6 +8,7 @@ import * as css from "./language-selector-button.scss";
 interface IProps {
   language: ILanguage;
   onClick: (lang: string) => void;
+  index: number;
 }
 
 export default class LanguageSelectorButton extends React.Component<IProps, {}> {
@@ -18,11 +19,12 @@ export default class LanguageSelectorButton extends React.Component<IProps, {}> 
   }
 
   public render() {
+    const { index } = this.props;
     const { lang, selected } = this.props.language;
     return (
       <Button
         data-cy="langToggle"
-        className={`${css.langButton} ${lang === "en" ? css.en : css.secondLang } ${selected ? css.selected : ""}`}
+        className={`${css.langButton} ${index === 0 ? css.firstLang : css.secondLang } ${selected ? css.selected : ""}`}
         label={POEDITOR_LANG_NAME[lang].replace("_", " ")}
         onClick={this.handleButtonClick}
       />

--- a/src/components/plugin/language-selector.tsx
+++ b/src/components/plugin/language-selector.tsx
@@ -24,11 +24,12 @@ export default class LanguageSelector extends React.Component<IProps, {}> {
 
     return (
       <div className={css.languageSelector}>
-        {languages.map(language => (
+        {languages.map((language, idx) => (
           <LanguageSelectorButton
             key={language.lang}
             language={language}
             onClick={onLanguageChange}
+            index={idx}
           />))}
       </div>
     );

--- a/src/components/plugin/plugin-app.test.tsx
+++ b/src/components/plugin/plugin-app.test.tsx
@@ -48,6 +48,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -78,6 +79,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -109,6 +111,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -136,6 +139,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -165,6 +169,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -192,6 +197,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -222,6 +228,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -247,6 +254,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -272,6 +280,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -307,6 +316,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
     expect(MockPluginAPI.addSidebar).toHaveBeenCalledTimes(1);
@@ -331,6 +341,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
 
@@ -357,6 +368,7 @@ describe("PluginApp component", () => {
         offlineMode={false}
         enableStudentLanguageSwitching={false}
         showIDontKnowButton={false}
+        showSecondLanguageFirst={false}
       />
     );
     expect(wrapper.find(GlossarySidebar).length).toEqual(0);
@@ -378,6 +390,7 @@ describe("PluginApp component", () => {
           offlineMode={false}
           enableStudentLanguageSwitching={false}
           showIDontKnowButton={false}
+          showSecondLanguageFirst={false}
         />
       );
       const pluginApp: PluginApp = (wrapper.instance() as PluginApp);
@@ -405,12 +418,40 @@ describe("PluginApp component", () => {
           offlineMode={false}
           enableStudentLanguageSwitching={false}
           showIDontKnowButton={false}
+          showSecondLanguageFirst={false}
         />
       );
       const pluginApp: PluginApp = (wrapper.instance() as PluginApp);
       expect(pluginApp.translate("submit")).toEqual("Submit");
       pluginApp.setState({ lang: "es" });
       expect(pluginApp.translate("submit")).toEqual("Enviar?!!");
+    });
+
+    it("should make the secondary language the default one if option is selected by author", () => {
+      const wrapper = mount(
+        <PluginApp
+          saveState={saveState}
+          definitions={definitions}
+          initialLearnerState={initialLearnerState}
+          askForUserDefinition={true}
+          autoShowMediaInPopup={false}
+          enableStudentRecording={false}
+          showSideBar={false}
+          disableReadAloud={false}
+          translations={{
+            es: {
+              submit: "Enviar?!!"
+            }
+          }}
+          offlineMode={false}
+          enableStudentLanguageSwitching={false}
+          showIDontKnowButton={false}
+          showSecondLanguageFirst={true}
+          secondLanguageCode="es"
+        />
+      );
+      const pluginApp: PluginApp = (wrapper.instance() as PluginApp);
+      expect(pluginApp.state.lang).toEqual("es");
     });
   });
 });

--- a/src/components/plugin/plugin-app.test.tsx
+++ b/src/components/plugin/plugin-app.test.tsx
@@ -427,31 +427,5 @@ describe("PluginApp component", () => {
       expect(pluginApp.translate("submit")).toEqual("Enviar?!!");
     });
 
-    it("should make the secondary language the default one if option is selected by author", () => {
-      const wrapper = mount(
-        <PluginApp
-          saveState={saveState}
-          definitions={definitions}
-          initialLearnerState={initialLearnerState}
-          askForUserDefinition={true}
-          autoShowMediaInPopup={false}
-          enableStudentRecording={false}
-          showSideBar={false}
-          disableReadAloud={false}
-          translations={{
-            es: {
-              submit: "Enviar?!!"
-            }
-          }}
-          offlineMode={false}
-          enableStudentLanguageSwitching={false}
-          showIDontKnowButton={false}
-          showSecondLanguageFirst={true}
-          secondLanguageCode="es"
-        />
-      );
-      const pluginApp: PluginApp = (wrapper.instance() as PluginApp);
-      expect(pluginApp.state.lang).toEqual("es");
-    });
   });
 });

--- a/src/hooks/use-migrate-glossary.ts
+++ b/src/hooks/use-migrate-glossary.ts
@@ -14,7 +14,8 @@ export const useMigrateGlossary = (initialGlossary: IGlossary, updateGlossary: (
       showIDontKnowButton: false,
       enableStudentRecording: false,
       enableStudentLanguageSwitching: false,
-      translations: {}
+      translations: {},
+      showSecondLanguageFirst: false
     }
     glossaryChanged = true
   }

--- a/src/i18n-context.test.ts
+++ b/src/i18n-context.test.ts
@@ -62,7 +62,8 @@ describe("pluginContext", () => {
         showIDontKnowButton: true,
         disableReadAloud: false,
         enableStudentRecording: true,
-        enableStudentLanguageSwitching: true
+        enableStudentLanguageSwitching: true,
+        showSecondLanguageFirst: false,
       };
       beforeEach(() => {
         fetch.mockResponse(JSON.stringify(glossary));

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -99,7 +99,6 @@ export class GlossaryPlugin {
         enableStudentRecording={authoredState.enableStudentRecording || false}
         enableStudentLanguageSwitching={authoredState.enableStudentLanguageSwitching || false}
         showSecondLanguageFirst={authoredState.showSecondLanguageFirst || false}
-        secondLanguageCode={authoredState.secondLanguageCode || ""}
         disableReadAloud={authoredState.disableReadAloud || false}
         translations={authoredState.translations || {}}
         showSideBar={authoredState.showSideBar || false}

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -98,6 +98,8 @@ export class GlossaryPlugin {
         autoShowMediaInPopup={authoredState.autoShowMediaInPopup || false}
         enableStudentRecording={authoredState.enableStudentRecording || false}
         enableStudentLanguageSwitching={authoredState.enableStudentLanguageSwitching || false}
+        showSecondLanguageFirst={authoredState.showSecondLanguageFirst || false}
+        secondLanguageCode={authoredState.secondLanguageCode || ""}
         disableReadAloud={authoredState.disableReadAloud || false}
         translations={authoredState.translations || {}}
         showSideBar={authoredState.showSideBar || false}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface IGlossary {
   enableStudentLanguageSwitching: boolean;
   translations?: ITranslationMap;
   tokenServiceResourceId?: string;
+  showSecondLanguageFirst: boolean;
+  secondLanguageCode?: string;
 }
 
 export type ITranslationMap = Record<string, ITranslation>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,6 @@ export interface IGlossary {
   translations?: ITranslationMap;
   tokenServiceResourceId?: string;
   showSecondLanguageFirst: boolean;
-  secondLanguageCode?: string;
 }
 
 export type ITranslationMap = Record<string, ITranslation>;

--- a/src/utils/translation-utils.test.tsx
+++ b/src/utils/translation-utils.test.tsx
@@ -16,7 +16,8 @@ describe("#glossaryToPOEditorTerms", () => {
       showIDontKnowButton: false,
       disableReadAloud: false,
       enableStudentRecording: false,
-      enableStudentLanguageSwitching: false
+      enableStudentLanguageSwitching: false,
+      showSecondLanguageFirst: false
     });
     expect(terms["cloud.word"]).toEqual("cloud");
     expect(terms["cloud.definition"]).toEqual("white thing");
@@ -43,6 +44,7 @@ describe("#isTranslationComplete", () => {
       disableReadAloud: false,
       enableStudentRecording: false,
       enableStudentLanguageSwitching: false,
+      showSecondLanguageFirst: false,
       translations: {
         es: {
           "cloud.word": "a",
@@ -69,6 +71,7 @@ describe("#isTranslationComplete", () => {
       enableStudentRecording: false,
       disableReadAloud: false,
       enableStudentLanguageSwitching: false,
+      showSecondLanguageFirst: false,
       translations: {
         es: {
           "cloud.word": "a",


### PR DESCRIPTION
This PR makes the following changes:
- New setting in the Glossary Settings panel on the right.
- The default for the setting is unchecked.
- When these options are selected and a teacher has enabled a preferred language for a student in the Glossary Dashboard, the student running will see their preferred language as the default language, and English as the secondary language