### PR TITLE
add data-testid tags to repo

### DIFF
--- a/src/components/model-authoring/glossary-settings.tsx
+++ b/src/components/model-authoring/glossary-settings.tsx
@@ -72,7 +72,7 @@ export const GlossarySettings = ({ name, glossary, project, projects, canEdit, s
         </div>
         <div className={css.settingInformation}>
           <div className={css.checkboxRow}>
-            <input type="checkbox" checked={askForUserDefinition} onChange={handleUserDefinitionChange()} />
+            <input type="checkbox" data-testid="student-provided-definitions-checkbox" checked={askForUserDefinition} onChange={handleUserDefinitionChange()} />
             <label>
               Require student-provided definitions
             </label>
@@ -85,7 +85,7 @@ export const GlossarySettings = ({ name, glossary, project, projects, canEdit, s
 
         <div className={`${css.settingInformation} ${css.nestedOptions}`}>
           <div className={css.checkboxRow}>
-            <input type="checkbox" disabled={!enabled} checked={showIDontKnowButton} onChange={handleChange("showIDontKnowButton")} />
+            <input type="checkbox" data-testid="display-i-dont-know-checkbox" disabled={!enabled} checked={showIDontKnowButton} onChange={handleChange("showIDontKnowButton")} />
             <label className={`${!enabled && css.disabled}`}>
               Display "I Don't Know" button
             </label>
@@ -98,7 +98,7 @@ export const GlossarySettings = ({ name, glossary, project, projects, canEdit, s
 
         <div className={`${css.settingInformation} ${css.nestedOptions}`}>
           <div className={css.checkboxRow}>
-            <input type="checkbox" disabled={!enabled} checked={enableStudentRecording} onChange={handleChange("enableStudentRecording")} />
+            <input type="checkbox" data-testid="student-audio-recording-checkbox" disabled={!enabled} checked={enableStudentRecording} onChange={handleChange("enableStudentRecording")} />
             <label className={`${!enabled && css.disabled}`}>
               Enable student audio recording for definitions
             </label>
@@ -110,7 +110,7 @@ export const GlossarySettings = ({ name, glossary, project, projects, canEdit, s
 
         <div className={css.settingInformation}>
           <div className={css.checkboxRow}>
-            <input type="checkbox" checked={autoShowMediaInPopup} onChange={handleChange("autoShowMediaInPopup")}/>
+            <input type="checkbox" data-testid="show-media-checkbox" checked={autoShowMediaInPopup} onChange={handleChange("autoShowMediaInPopup")}/>
             <label>
               Automatically show media (image or video)
             </label>
@@ -125,7 +125,7 @@ export const GlossarySettings = ({ name, glossary, project, projects, canEdit, s
 
         <div className={css.settingInformation}>
           <div className={css.checkboxRow}>
-            <input type="checkbox" checked={disableReadAloud} onChange={handleChange("disableReadAloud")}/>
+            <input type="checkbox" data-testid="disable-read-aloud-checkbox" checked={disableReadAloud} onChange={handleChange("disableReadAloud")}/>
             <label>
               Disable read-aloud buttons
             </label>
@@ -138,7 +138,7 @@ export const GlossarySettings = ({ name, glossary, project, projects, canEdit, s
 
         <div className={css.settingInformation}>
           <div className={css.checkboxRow}>
-            <input type="checkbox" checked={showSideBar} onChange={handleChange("showSideBar")}/>
+            <input type="checkbox" data-testid="show-glossary-sidebar-checkbox" checked={showSideBar} onChange={handleChange("showSideBar")}/>
             <label>
               Show Glossary Sidebar on activity pages
             </label>
@@ -151,7 +151,7 @@ export const GlossarySettings = ({ name, glossary, project, projects, canEdit, s
 
         <div className={css.settingInformation}>
           <div className={css.checkboxRow}>
-            <input type="checkbox" checked={showSecondLanguageFirst} onChange={handleChange("showSecondLanguageFirst")}/>
+            <input type="checkbox" data-testid="display-second-language-first-checkbox" checked={showSecondLanguageFirst} onChange={handleChange("showSecondLanguageFirst")}/>
             <label>
               Display Second Language First
             </label>

--- a/src/components/model-authoring/term-popup-preview.tsx
+++ b/src/components/model-authoring/term-popup-preview.tsx
@@ -120,7 +120,7 @@ export const TermPopUpPreview = (props: IProps) => {
           <div className={css.header}>
             <h4>Term: {term.word}</h4>
           </div>
-          <div className={css.innerPopup}>
+          <div className={css.innerPopup} data-testid="term-popup-preview-inner">
             <GlossaryPopup
               demoMode={true}
               word={term.word}
@@ -148,7 +148,7 @@ export const TermPopUpPreview = (props: IProps) => {
         </div>
         {renderLanguageSelector()}
         {note && <div className={css.note}>{note}</div>}
-        {allowReset && <button className={css.resetButton} onClick={onReset}>{resetLabel || "Reset"}</button>}
+        {allowReset && <button className={css.resetButton} onClick={onReset} data-testid="reset-term-popup-preview">{resetLabel || "Reset"}</button>}
       </div>
     </pluginContext.Provider>
   )

--- a/src/components/plugin/definition.tsx
+++ b/src/components/plugin/definition.tsx
@@ -124,10 +124,10 @@ export default class Definition extends React.Component<IProps, IState> {
     const { imageVisible, videoVisible, diggingDeeperVisible } = this.state;
     const hasDefinition = definition.length > 0
     return (
-      <div>
+      <div data-testid="definition">
         {hasDefinition && <div>
-          <span className={css.disableSelect}>{this.translatedDefinition}</span>
-          <span className={css.icons}>
+          <span className={css.disableSelect} data-testid="definition-text">{this.translatedDefinition}</span>
+          <span className={css.icons} data-testid="definition-icons">
             {!disableReadAloud && <TextToSpeech text={this.translatedDefinition} word={word} textKey={TextKey.Definition} />}
             {this.renderImageButton(imageUrl)}
             {this.renderVideoButton(videoUrl)}

--- a/src/components/plugin/digging-deeper.tsx
+++ b/src/components/plugin/digging-deeper.tsx
@@ -30,9 +30,9 @@ class DiggingDeeper extends React.Component<IProps>{
 	render(){
 		const { word, disableReadAloud } = this.props;
 		return (
-			<div className={css.container}>
-				<h4>{this.translatedDiggingDeeperTitle}</h4>
-				<div className={css.diggingDeeper}>
+			<div className={css.container} data-testid="digging-deeper">
+				<h4 data-testid="digging-deeper-title">{this.translatedDiggingDeeperTitle}</h4>
+				<div className={css.diggingDeeper} data-testid="digging-deeper-content">
 					{this.translatedDiggingDeeperDefinition}
 					{!disableReadAloud && <TextToSpeech text={this.translatedDiggingDeeperDefinition} word={word} textKey={TextKey.DiggingDeeper} />}
 				</div>

--- a/src/components/plugin/glossary-popup.tsx
+++ b/src/components/plugin/glossary-popup.tsx
@@ -211,7 +211,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
         }
         {this.mainPrompt}
         {!disableReadAloud && <TextToSpeech text={this.mainPrompt} word={word} textKey={TextKey.MainPrompt} />}
-        <div className={css.answerTextarea}>
+        <div className={css.answerTextarea} data-testid="term-popup-preview-answer-textarea">
           {recording && this.renderRecording()}
           {!recording &&
             <>
@@ -235,7 +235,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
         <div className={css.buttons}>
           <div
             className={`${css.button} ${canSubmit ? "" : css.disabled}`}
-            data-cy="submit"
+            data-testid="term-popup-preview-submit-button"
             onClick={canSubmit ? this.handleSubmit : undefined}
           >
             {i18n.translate("submit")}
@@ -244,7 +244,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
           { showIDontKnowButton &&
           <div
             className={css.button}
-            data-cy="cancel"
+            data-testid="cancel"
             onClick={anyUserDef ? this.handleCancel : this.handleIDontKnow}
           >
             {anyUserDef ? i18n.translate("cancel") : i18n.translate("iDontKnowYet")}
@@ -336,7 +336,7 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
         <div className={css.answerTextareaIcons}>
           {!disableReadAloud && <TextToSpeech text={this.answerPlaceholder} word={word} textKey={TextKey.WriteDefinition} />}
           {canRecord && <span
-            data-cy="recordButton"
+            data-testid="record-button"
             className={icons.iconButton + " " + icons.iconRecord}
             onClick={this.handleStartRecording}
             title={i18n.translate("record")}

--- a/src/components/plugin/image.tsx
+++ b/src/components/plugin/image.tsx
@@ -52,19 +52,20 @@ export default class Image extends React.Component<IProps, IState> {
     const translate = this.context.translate;
     return (
       <>
-        <div className={css.imageContainer}>
-          <div className={css.imageWrapper} onClick={this.toggleImageZoom}>
-            <img src={imageUrl} title={this.translatedImageAltText} alt={this.translatedImageAltText}/>
+        <div className={css.imageContainer} data-testid="image-container">
+          <div className={css.imageWrapper} onClick={this.toggleImageZoom} data-testid="image-wrapper">
+            <img src={imageUrl} title={this.translatedImageAltText} alt={this.translatedImageAltText} data-testid="image"/>
             <div className={css.zoomButton}>
               <span
                 className={icons.iconButton + " " + icons.iconZoomIn}
                 title={translate("zoomInTitle")}
+                data-testid="zoom-button"
               />
             </div>
           </div>
           {
             this.translatedImageCaption &&
-            <div className={css.caption}>
+            <div className={css.caption} data-testid="image-caption">
               {this.translatedImageCaption}
               {!disableReadAloud && <TextToSpeech text={this.translatedImageCaption} word={word} textKey={TextKey.ImageCaption} />}
             </div>

--- a/src/components/plugin/language-selector-button.tsx
+++ b/src/components/plugin/language-selector-button.tsx
@@ -23,6 +23,7 @@ export default class LanguageSelectorButton extends React.Component<IProps, {}> 
     const { lang, selected } = this.props.language;
     return (
       <Button
+        data-testid={`language-selector-button-${lang}`}
         data-cy="langToggle"
         className={`${css.langButton} ${index === 0 ? css.firstLang : css.secondLang } ${selected ? css.selected : ""}`}
         label={POEDITOR_LANG_NAME[lang].replace("_", " ")}

--- a/src/components/plugin/language-selector.tsx
+++ b/src/components/plugin/language-selector.tsx
@@ -23,7 +23,7 @@ export default class LanguageSelector extends React.Component<IProps, {}> {
     }
 
     return (
-      <div className={css.languageSelector}>
+      <div className={css.languageSelector} data-testid="language-selector">
         {languages.map((language, idx) => (
           <LanguageSelectorButton
             key={language.lang}

--- a/src/components/plugin/text-to-speech.tsx
+++ b/src/components/plugin/text-to-speech.tsx
@@ -58,6 +58,7 @@ export default class TextToSpeech extends React.Component<IProps, IState> {
         className={icons.iconButton + " " + (reading ? icons.iconStop : icons.iconAudio)}
         onClick={this.read}
         title={translate("speechTitle")}
+        data-testid="text-to-speech-button"
       />
     );
   }

--- a/src/components/plugin/video.tsx
+++ b/src/components/plugin/video.tsx
@@ -41,22 +41,23 @@ export default class Video extends React.Component<IProps> {
     const {lang} = this.context;
 
     return (
-      <div className={css.videoContainer}>
+      <div className={css.videoContainer} data-testid="video-container">
       {
         this.translatedClosedCaptionsUrl ?
-        <video src={videoUrl} title={this.translatedVideoAltText} crossOrigin={"anonymous"} controls={true}>
+        <video src={videoUrl} title={this.translatedVideoAltText} crossOrigin={"anonymous"} controls={true} data-testid="video-with-captions">
           <track
             kind="subtitles"
             srcLang={lang}
             src={this.translatedClosedCaptionsUrl}
             default={false}
+            data-testid="video-track"
           />
         </video> :
-        <video src={videoUrl} title={this.translatedVideoAltText} controls={true}/>
+        <video src={videoUrl} title={this.translatedVideoAltText} controls={true} data-testid="video"/>
       }
       {
         this.translatedVideoCaption &&
-        <div className={css.caption}>
+        <div className={css.caption} data-testid="video-caption">
           {this.translatedVideoCaption}
           {
             !disableReadAloud &&


### PR DESCRIPTION
[LARA-183](https://concord-consortium.atlassian.net/browse/LARA-183)
This PR adds data-testid tags to the glossary plugin. While in there I veered towards "more is better" in this PR since I don't know who will be in there again any time soon. 😂 
- Added data-testid attributes to the Definition component and its subcomponents
- Added data-testid attributes to the Image component and its zoom functionality
- Added data-testid attributes to the Video component and its caption features
- Added data-testid attributes to the DiggingDeeper component
- Added data-testid attributes to the TextToSpeech component

The lint errors I see seem to have been there before I started this PR and I didn't address them.

[LARA-183]: https://concord-consortium.atlassian.net/browse/LARA-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ